### PR TITLE
feat: add from/to time range filters to TransactionOptions

### DIFF
--- a/src/api/pools.ts
+++ b/src/api/pools.ts
@@ -184,7 +184,9 @@ export class PoolsAPI extends BaseAPI {
     };
     
     if (options?.cursor) params.cursor = options.cursor;
-    
+    if (options?.from !== undefined) params.from = options.from;
+    if (options?.to !== undefined) params.to = options.to;
+
     return this._get(`/networks/${networkId}/pools/${poolAddress}/transactions`, params);
   }
   

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -51,6 +51,10 @@ export interface PoolDetailsOptions {
 export interface TransactionOptions extends PaginationOptions {
   /** Cursor for paginated results */
   cursor?: string;
+  /** Filter transactions starting from this UNIX timestamp (inclusive). Results capped to last 7 days. */
+  from?: number;
+  /** Filter transactions up to this UNIX timestamp (exclusive). Must be after `from`. */
+  to?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **TransactionOptions**: new optional `from`/`to` fields (UNIX timestamps) for time-range filtering (results capped to last 7 days)
- **getTxs/getTransactions**: forwards from/to params to API
- Token types already have telegram/twitter fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)