### PR TITLE
ci: add build + CodeQL workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20.x', '22.x']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check + build
+        run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript', 'actions']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
TS SDK had no CI workflows. Python and Go SDKs both have build + CodeQL. This brings TS to parity.

4 stale dependabot PRs (#27, #37, #44, #45) sit unverified because of this gap. Once CI lands, `@dependabot rebase` on each unblocks them.

## What's added
- `build.yml`: `npm ci && npm run build` on Node 20 and 22 matrix
- `codeql.yml`: JS/TS + actions security scanning

Both pin `permissions: contents: read` at the workflow root, matching r--w's hardening pattern across other SDKs.

## What's not (deliberate)
- No live tests in CI. `tests/test-basic.ts` calls `api.dexpaprika.com`. Phase 2 will split unit (mocked, run on every PR) from integration (gated on env var + schedule).
- No publish workflow. Needs `NPM_TOKEN` and a release-strategy decision. Separate PR.
- No eslint/prettier. Bigger scope. Separate PR.

## Test plan
- [x] `npm ci && npm run build` runs locally on a fresh worktree of main
- [ ] CI green on this PR (build matrix + CodeQL)
- [ ] After merge: `@dependabot rebase` on #27, #37, #44, #45