### PR TITLE
fix: set explicit rootDir for TS 6+ strict compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,6 +60,7 @@
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "rootDir": "./src",                                /* Explicit rootDir for TS 6+ strict requirement (was inferred in 5.x). */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
## What

One-line tsconfig change: add `"rootDir": "./src"`.

## Why

TypeScript 6.0 made `rootDir` strict. It used to be inferred from `include: ["src/**/*"]` on TS 5.x. On TS 6.x the bare `tsc` fails with [TS5011](https://aka.ms/ts6) when `rootDir` is not explicit. This blocks dependabot's TS 5.8.3 → 6.0.3 bump (#27) on the new build CI.

Setting `rootDir: "./src"` matches what TS was already inferring, so no change to emitted output or public `.d.ts` files.

## Verified locally

```
TS 5.8.3 (current) → npm run build → exit 0
TS 6.0.3 (target)  → npm run build → exit 0
```

## After merging

Comment `@dependabot rebase` on #27 → it picks up the new tsconfig → CI green → mergeable.