### PR TITLE
Fix pool/token filter endpoint types (silent data loss + empty results)

### DIFF
--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -105,10 +105,13 @@ export class TokensAPI extends BaseAPI {
     if (options?.createdAfter !== undefined) params.created_after = options.createdAfter;
     if (options?.createdBefore !== undefined) params.created_before = options.createdBefore;
 
-    return this._get<TokenFilterPaginatedResponse>(
-      `/networks/${networkId}/tokens/filter`,
-      params
-    );
+    // The token filter endpoint returns its rows under a "data" key. Remap to
+    // "results" so the response matches the other filter endpoints' shape.
+    const raw = await this._get<{
+      data?: TokenFilterPaginatedResponse['results'];
+      page_info: TokenFilterPaginatedResponse['page_info'];
+    }>(`/networks/${networkId}/tokens/filter`, params);
+    return { results: raw.data ?? [], page_info: raw.page_info };
   }
 
   /**

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -1,6 +1,6 @@
 // We'll need to import these types to avoid reference errors
 import { Dex } from './dexes';
-import { Pool } from './pools';
+import { Pool, FilteredPool } from './pools';
 
 // page info for pagination
 export interface PageInfo {
@@ -31,6 +31,6 @@ export interface PoolPaginatedResponse {
 
 // pool filter response (uses 'results' key)
 export interface PoolFilterPaginatedResponse {
-  results: Pool[];
+  results: FilteredPool[];
   page_info: PageInfo;
 }

--- a/src/models/pools.ts
+++ b/src/models/pools.ts
@@ -38,6 +38,29 @@ export interface Pool {
   liquidity_usd?: number;
 }
 
+// Pool from the filter endpoint (/networks/{id}/pools/filter).
+// Unlike the list endpoint, the filter endpoint returns timeframe-split volume
+// (volume_usd_24h/_7d/_30d) and liquidity_usd, and no flat volume_usd.
+export interface FilteredPool {
+  id: string;
+  dex_id: string;
+  dex_name: string;
+  chain: string;
+  tokens: Token[];
+  created_at?: string;
+  created_at_block_number?: number;
+  transactions?: number;
+  price_usd?: number;
+  volume_usd_24h?: number;
+  volume_usd_7d?: number;
+  volume_usd_30d?: number;
+  liquidity_usd?: number;
+  last_price_change_usd_5m?: number | null;
+  last_price_change_usd_1h?: number | null;
+  last_price_change_usd_24h?: number | null;
+  fee?: number | null;
+}
+
 // alias for backward compat
 export type PoolsResponse = PoolPaginatedResponse;
 

--- a/src/models/tokens.ts
+++ b/src/models/tokens.ts
@@ -191,6 +191,7 @@ export interface FilteredToken {
   price_usd?: number;
   volume_usd_24h?: number;
   volume_usd_7d?: number;
+  volume_usd_30d?: number;
   liquidity_usd?: number;
   fdv_usd?: number;
   txns_24h?: number;


### PR DESCRIPTION
## Problem
`pools.filter()` and `tokens.filter()` returned wrong/empty data against the live API. The SDK does **no runtime validation** (plain casts of `response.data`), so this failed **silently** rather than throwing:
- **Pool filter:** `volume_usd` was `undefined` and the real timeframe volumes weren't typed.
- **Token filter:** `results` was always `undefined`/empty.

## Root cause (verified live)
- `/pools/filter` returns `volume_usd_24h/_7d/_30d` + `liquidity_usd` and **no flat `volume_usd`**, but the response reused the list `Pool` type (required `volume_usd`, no 24h/30d).
- `/tokens/filter` returns rows under a **`data`** key, but the type read `results`.

## Fix
- New **`FilteredPool`** type with the real filter fields; `PoolFilterPaginatedResponse` uses it.
- `tokens.filter()` **remaps `data` → `results`** so the public `{ results }` shape stays consistent with the pool filter and the Python/Go SDKs. Added `volume_usd_30d` to `FilteredToken`.

## Verification
`tsc` build clean; ran the live endpoint test suite — **13/13 pass**. `tokens.filter` now returns rows (was empty); `pools.filter` rows carry `volume_usd_24h`.

Cross-SDK fix for the same drift (Python: dexpaprika-sdk-python#7, Go: dexpaprika-sdk-go#10). Refs coinpaprika/devrel#40.
