### PR TITLE
feat: advanced pool search (/frontend/v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the DexPaprika SDK will be documented in this file.
 
+## Unreleased
+
+### Added
+- **Advanced pool search**: `pools.advancedSearch()` (alias `pools.search()`) backed by the `/frontend/v1/pools` and `/frontend/v1/networks/{network}/pools` endpoints. Supports price and price-change filters, a `dexName` filter, an optional `detailed` token payload (fdv + per-timeframe metric blocks), and cursor pagination. The canonical `sortBy` / `sortDir` options are translated to the backend wire names `order_by` / `sort`.
+- New TypeScript interfaces: `AdvancedPoolSearchOptions`, `AdvancedPoolSearchSortBy`, `AdvancedPoolSearchResponse`, `PoolRow`, `AdvancedSearchToken`, `AdvancedSearchTokenMetrics`. Response and token fields are optional/nullable to match what the API may omit.
+
 ## 1.5.0 (2026-03-31)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -239,6 +239,34 @@ const filtered = await client.pools.filter('ethereum', {
 console.log(`Found ${filtered.results.length} pools matching criteria`);
 ```
 
+### Advanced Pool Search
+
+```js
+// Richer search than filter(): price/price-change filters, dex filter,
+// optional detailed token payload (fdv + per-timeframe metrics), cursor paging.
+// Sort takes the canonical sortBy/sortDir (translated to order_by/sort on the wire).
+const res = await client.pools.advancedSearch({
+  limit: 20,
+  sortBy: 'volume_usd_24h',
+  sortDir: 'desc',
+  priceUsdMin: 0.5,
+  dexName: 'uniswap_v3',
+  detailed: true
+});
+console.log(`Found ${res.results.length} pools`);
+
+// Scope to one network:
+const eth = await client.pools.advancedSearch({ network: 'ethereum', limit: 10 });
+
+// Cursor pagination (this endpoint is NOT page-based):
+if (eth.has_next_page && eth.next_cursor) {
+  const page2 = await client.pools.advancedSearch({ network: 'ethereum', cursor: eth.next_cursor });
+}
+
+// search() is an alias for advancedSearch().
+const same = await client.pools.search({ limit: 5 });
+```
+
 ### Top Tokens & Token Filtering
 
 ```js

--- a/src/api/pools.ts
+++ b/src/api/pools.ts
@@ -3,13 +3,18 @@ import {
   PoolDetails,
   OHLCVRecord
 } from '../models/pools';
-import { PoolPaginatedResponse, PoolFilterPaginatedResponse } from '../models/base';
+import {
+  PoolPaginatedResponse,
+  PoolFilterPaginatedResponse,
+  AdvancedPoolSearchResponse,
+} from '../models/base';
 import {
   PoolListOptions,
   OHLCVOptions,
   PoolDetailsOptions,
   TransactionOptions,
   PoolFilterOptions,
+  AdvancedPoolSearchOptions,
 } from '../models/options';
 import { DeprecatedEndpointError } from '../utils/errors';
 
@@ -239,5 +244,100 @@ export class PoolsAPI extends BaseAPI {
     if (options?.createdBefore !== undefined) params.created_before = options.createdBefore;
 
     return this._get<PoolFilterPaginatedResponse>(`/networks/${networkId}/pools/filter`, params);
+  }
+
+  /**
+   * Advanced pool search backed by the /frontend/v1 endpoints.
+   *
+   * Hits `/frontend/v1/pools` globally, or
+   * `/frontend/v1/networks/{network}/pools` when a network is supplied. This is
+   * a richer search than `filter`: it supports price and price-change filters,
+   * a `dexName` filter, an optional `detailed` token payload (fdv + per-timeframe
+   * metric blocks), and CURSOR pagination.
+   *
+   * This endpoint is cursor-paginated, not page-based. Walk pages by passing the
+   * previous response's `next_cursor` back in as `cursor`, while `has_next_page`
+   * is true.
+   *
+   * Sorting note: the surface takes the canonical `sortBy` / `sortDir`, which are
+   * translated to the backend wire names `order_by` / `sort`. Do not pass the wire
+   * names yourself.
+   *
+   * @example
+   * ```typescript
+   * // Global search, top pools by 24h volume priced above $0.50 on Uniswap V3:
+   * const res = await client.pools.advancedSearch({
+   *   limit: 20,
+   *   sortBy: 'volume_usd_24h',
+   *   sortDir: 'desc',
+   *   priceUsdMin: 0.5,
+   *   dexName: 'uniswap_v3',
+   *   detailed: true,
+   * });
+   *
+   * // Per-network search (Ethereum):
+   * const ethRes = await client.pools.advancedSearch({ network: 'ethereum', limit: 10 });
+   *
+   * // Next page:
+   * if (ethRes.has_next_page && ethRes.next_cursor) {
+   *   const page2 = await client.pools.advancedSearch({ network: 'ethereum', cursor: ethRes.next_cursor });
+   * }
+   * ```
+   *
+   * @param options - Search criteria, sorting, detail flag, cursor, and an optional `network`.
+   * @returns Matching pool rows with cursor pagination info.
+   */
+  async advancedSearch(
+    options?: AdvancedPoolSearchOptions & { network?: string }
+  ): Promise<AdvancedPoolSearchResponse> {
+    // Translate the canonical sortBy/sortDir to the wire names order_by/sort.
+    // This is the inverse of intuition and the #1 trap for this endpoint.
+    const params: Record<string, any> = {
+      limit: options?.limit ?? 10,
+      order_by: options?.sortBy ?? 'volume_usd_24h',
+      sort: options?.sortDir ?? 'desc',
+    };
+
+    if (options?.cursor) params.cursor = options.cursor;
+    if (options?.detailed) params.detailed = 'true';
+
+    if (options?.volume24hMin !== undefined) params.volume_24h_min = options.volume24hMin;
+    if (options?.volume24hMax !== undefined) params.volume_24h_max = options.volume24hMax;
+    if (options?.volume7dMin !== undefined) params.volume_7d_min = options.volume7dMin;
+    if (options?.volume7dMax !== undefined) params.volume_7d_max = options.volume7dMax;
+    if (options?.liquidityUsdMin !== undefined) params.liquidity_usd_min = options.liquidityUsdMin;
+    if (options?.liquidityUsdMax !== undefined) params.liquidity_usd_max = options.liquidityUsdMax;
+    if (options?.txns24hMin !== undefined) params.txns_24h_min = options.txns24hMin;
+    if (options?.priceUsdMin !== undefined) params.price_usd_min = options.priceUsdMin;
+    if (options?.priceUsdMax !== undefined) params.price_usd_max = options.priceUsdMax;
+    if (options?.priceChangePercentage24hMin !== undefined) {
+      params.price_change_percentage_24h_min = options.priceChangePercentage24hMin;
+    }
+    if (options?.priceChangePercentage24hMax !== undefined) {
+      params.price_change_percentage_24h_max = options.priceChangePercentage24hMax;
+    }
+    if (options?.dexName !== undefined) params.dex_name = options.dexName;
+    if (options?.createdAfter !== undefined) params.created_after = options.createdAfter;
+    if (options?.createdBefore !== undefined) params.created_before = options.createdBefore;
+
+    const endpoint = options?.network
+      ? `/frontend/v1/networks/${options.network}/pools`
+      : '/frontend/v1/pools';
+
+    const raw = await this._get<AdvancedPoolSearchResponse>(endpoint, params);
+    // Never hand back an undefined results array (the API may drop the key).
+    return { ...raw, results: raw.results ?? [] };
+  }
+
+  /**
+   * Alias for {@link advancedSearch}.
+   *
+   * @param options - Search criteria, sorting, detail flag, cursor, and an optional `network`.
+   * @returns Matching pool rows with cursor pagination info.
+   */
+  search(
+    options?: AdvancedPoolSearchOptions & { network?: string }
+  ): Promise<AdvancedPoolSearchResponse> {
+    return this.advancedSearch(options);
   }
 }

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -1,6 +1,6 @@
 // We'll need to import these types to avoid reference errors
 import { Dex } from './dexes';
-import { Pool, FilteredPool } from './pools';
+import { Pool, FilteredPool, PoolRow } from './pools';
 
 // page info for pagination
 export interface PageInfo {
@@ -33,4 +33,19 @@ export interface PoolPaginatedResponse {
 export interface PoolFilterPaginatedResponse {
   results: FilteredPool[];
   page_info: PageInfo;
+}
+
+// Response from the advanced pool search endpoint (/frontend/v1/pools and
+// /frontend/v1/networks/{network}/pools). Unlike the other pool endpoints this
+// one is CURSOR-paginated: there is no page_info, you walk pages by passing
+// next_cursor back in as `cursor` while has_next_page is true.
+export interface AdvancedPoolSearchResponse {
+  // Matching pools. Defaults to an empty array if the API omits the key.
+  results: PoolRow[];
+  // True while there is another page to fetch.
+  has_next_page?: boolean;
+  // Opaque cursor for the next page; null on the last page.
+  next_cursor?: string | null;
+  // Echo of the (wire-name) query parameters the API actually applied.
+  query?: Record<string, unknown>;
 }

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -106,6 +106,72 @@ export interface PoolFilterOptions {
 }
 
 /**
+ * Sort field for the advanced pool search endpoint.
+ * Exposed as the canonical `sortBy`; translated to the wire name `order_by`.
+ */
+export type AdvancedPoolSearchSortBy =
+  | 'volume_usd_24h'
+  | 'volume_usd_7d'
+  | 'volume_usd_30d'
+  | 'liquidity_usd'
+  | 'txns_24h'
+  | 'price_usd'
+  | 'price_change_percentage_24h'
+  | 'created_at';
+
+/**
+ * Options for the advanced pool search endpoint
+ * (`/frontend/v1/pools` and `/frontend/v1/networks/{network}/pools`).
+ *
+ * This endpoint is CURSOR-paginated (not page-based): pass `cursor` with the
+ * `next_cursor` from the previous response to fetch the next page.
+ *
+ * Note on sorting: this surface exposes the canonical `sortBy` / `sortDir`
+ * names, which are translated to the backend wire names `order_by` / `sort`.
+ * You never pass `order_by` / `sort` yourself.
+ */
+export interface AdvancedPoolSearchOptions {
+  /** Number of results per page. */
+  limit?: number;
+  /** Cursor for the next page (use `next_cursor` from the previous response). */
+  cursor?: string;
+  /** Field to sort by. Canonical name; translated to the wire `order_by`. Defaults to "volume_usd_24h". */
+  sortBy?: AdvancedPoolSearchSortBy | string;
+  /** Sort direction. Canonical name; translated to the wire `sort`. Defaults to "desc". */
+  sortDir?: 'asc' | 'desc';
+  /** When true, each token carries fdv plus per-timeframe metric blocks. */
+  detailed?: boolean;
+  /** Minimum 24h volume in USD. */
+  volume24hMin?: number;
+  /** Maximum 24h volume in USD. */
+  volume24hMax?: number;
+  /** Minimum 7d volume in USD. */
+  volume7dMin?: number;
+  /** Maximum 7d volume in USD. */
+  volume7dMax?: number;
+  /** Minimum liquidity in USD. */
+  liquidityUsdMin?: number;
+  /** Maximum liquidity in USD. */
+  liquidityUsdMax?: number;
+  /** Minimum 24h transaction count. */
+  txns24hMin?: number;
+  /** Minimum price in USD. */
+  priceUsdMin?: number;
+  /** Maximum price in USD. */
+  priceUsdMax?: number;
+  /** Minimum 24h price change percentage. */
+  priceChangePercentage24hMin?: number;
+  /** Maximum 24h price change percentage. */
+  priceChangePercentage24hMax?: number;
+  /** Filter by DEX name (e.g. "uniswap_v3"). */
+  dexName?: string;
+  /** Only pools created after this Unix timestamp or ISO date. */
+  createdAfter?: number | string;
+  /** Only pools created before this Unix timestamp or ISO date. */
+  createdBefore?: number | string;
+}
+
+/**
  * Options for top tokens endpoint
  */
 export interface TopTokensOptions {

--- a/src/models/pools.ts
+++ b/src/models/pools.ts
@@ -61,6 +61,72 @@ export interface FilteredPool {
   fee?: number | null;
 }
 
+// Per-timeframe metrics block returned for a token when advanced search is
+// called with detailed=true. The API keys these blocks "1m", "5m", "15m",
+// "30m", "1h", "6h", "24h". Every field is optional because the API may omit
+// any of them.
+export interface AdvancedSearchTokenMetrics {
+  volume_usd?: number;
+  buys?: number;
+  sells?: number;
+  txns?: number;
+  last_price_usd_change?: number | null;
+}
+
+// Token nested inside an advanced search PoolRow (/frontend/v1/pools).
+// This endpoint returns a much leaner token by default than the rest of the
+// SDK: without detailed=true you may only get id, chain and has_image. With
+// detailed=true the token carries the descriptive fields plus fdv and the
+// per-timeframe metric blocks. Everything here is optional so we never break
+// on a field the API drops.
+export interface AdvancedSearchToken {
+  id?: string;
+  chain?: string;
+  has_image?: boolean;
+  name?: string;
+  symbol?: string;
+  status?: string;
+  decimals?: number;
+  total_supply?: number;
+  description?: string;
+  website?: string;
+  added_at?: string;
+  fdv?: number;
+  // Per-timeframe metric blocks (present when detailed=true).
+  '1m'?: AdvancedSearchTokenMetrics;
+  '5m'?: AdvancedSearchTokenMetrics;
+  '15m'?: AdvancedSearchTokenMetrics;
+  '30m'?: AdvancedSearchTokenMetrics;
+  '1h'?: AdvancedSearchTokenMetrics;
+  '6h'?: AdvancedSearchTokenMetrics;
+  '24h'?: AdvancedSearchTokenMetrics;
+}
+
+// A single pool row from the advanced search endpoint (/frontend/v1/pools and
+// /frontend/v1/networks/{network}/pools). This shape differs from both Pool
+// and FilteredPool: it carries price_change_percentage_* fields and leans on
+// timeframe-split volume. Fields are optional/nullable because the API may
+// omit them depending on the pool and the requested detail level.
+export interface PoolRow {
+  id: string;
+  dex_id?: string;
+  dex_name?: string;
+  chain?: string;
+  fee?: number | null;
+  created_at?: string;
+  created_at_block_number?: number;
+  price_usd?: number;
+  transactions_24h?: number;
+  volume_usd_24h?: number;
+  volume_usd_7d?: number;
+  volume_usd_30d?: number;
+  liquidity_usd?: number;
+  price_change_percentage_5m?: number | null;
+  price_change_percentage_1h?: number | null;
+  price_change_percentage_24h?: number | null;
+  tokens?: AdvancedSearchToken[];
+}
+
 // alias for backward compat
 export type PoolsResponse = PoolPaginatedResponse;
 


### PR DESCRIPTION
Adds `pools.advancedSearch()` (with `pools.search()` as an alias) backed by the `/frontend/v1` pool endpoints:

- global: `GET /frontend/v1/pools`
- per-network: `GET /frontend/v1/networks/{network}/pools`

This is a richer search than the existing `filter()`. On top of volume/liquidity/txns it adds price and price-change filters, a `dexName` filter, and an optional `detailed` flag that makes each token carry `fdv` plus per-timeframe metric blocks (`1m`/`5m`/`15m`/`30m`/`1h`/`6h`/`24h`).

## The sort trap
The backend wires sorting as `order_by` (field) + `sort` (direction), which is the inverse of what you'd guess. I kept that off the public surface: the method takes the canonical `sortBy` / `sortDir` and translates them to `order_by` / `sort` on the request. Callers never touch the wire names.

## Cursor pagination
This endpoint is cursor-based, not page-based. The response is `{ results, has_next_page, next_cursor, query }` (no `page_info`). To page, you pass the previous `next_cursor` back in as `cursor`.

## Optional fields on purpose
Every new response and token field is optional/nullable. Without `detailed=true` the token comes back lean (sometimes just `id`/`chain`/`has_image`); with it you get the descriptive fields plus `fdv` and the timeframe blocks. Since this SDK casts straight to its types with no runtime validation, the types have to match what the wire actually sends, and the wire drops fields. Hard-requiring one of them is exactly what broke the pool/token filter types before, so I avoided it here.

## What changed
- `src/api/pools.ts` — `advancedSearch()` + `search()` alias, with the `sortBy/sortDir -> order_by/sort` translation and the global vs per-network endpoint switch.
- `src/models/pools.ts` — `PoolRow`, `AdvancedSearchToken`, `AdvancedSearchTokenMetrics`.
- `src/models/base.ts` — `AdvancedPoolSearchResponse` (cursor shape).
- `src/models/options.ts` — `AdvancedPoolSearchOptions`, `AdvancedPoolSearchSortBy`.
- `README.md`, `CHANGELOG.md` — docs.

## Verification
- `npm install` + `npm run build` (tsc clean, exit 0).
- A `ts-node --transpile-only` script hitting the live API:
  - global call with `sortBy: volume_usd_24h`, `priceUsdMin: 0.5`, `dexName: uniswap_v3`, `detailed: true` returns non-empty results; every row is `uniswap_v3` with `price_usd >= 0.5`; the first token carries `fdv` and a `24h` block.
  - the `query` echo confirms the translation reached the wire: `{"order_by":"volume_usd_24h","sort":"desc",...}`.
  - per-network (`ethereum`) returns non-empty results all scoped to `ethereum`, sorted by volume descending.
  - cursor round-trip: passing `next_cursor` back in returns a distinct second page.
  - `search()` alias works.