### PR TITLE
Fix 410s: migrate pool/token list+filter methods to /search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the DexPaprika SDK will be documented in this file.
 
+## 1.6.0 (2026-06-30)
+
+### Breaking Changes
+- The DexPaprika API removed four REST endpoints (now HTTP 410): `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, and `/networks/{network}/tokens/filter`.
+- `pools.listByNetwork()`, `pools.filter()`, `tokens.getTop()`, and `tokens.filter()` now call the unified search endpoints `/networks/{network}/pools/search` and `/networks/{network}/tokens/search`.
+- These four methods now return the cursor-paginated search shape: `{ results, has_next_page, next_cursor }` instead of `{ pools | tokens, page_info }`. Read the next page from `next_cursor` and pass it back via the new `cursor` option (`page` is ignored).
+- Item field changes: pool results expose `volume_usd_24h`/`volume_usd_7d`/`volume_usd_30d`, `liquidity_usd`, `transactions_24h`, and `price_change_percentage_5m`/`1h`/`24h` (the flat `volume_usd`, `transactions`, and `last_price_change_usd_*` fields are gone). Pool `tokens` are lean refs (`id`, `chain`, `has_image`) by default; `name`/`symbol`/`decimals` are typed as optional. Token results are flat (`address`, `volume_usd_24h`, `fdv_usd`, `txns_24h`, `price_change_percentage_24h`, ...) with no `name`/`symbol`/nested timeframe objects.
+
+### Changed
+- Public method signatures and option types are unchanged for back-compat: legacy `orderBy`/`sortBy` values (e.g. `volume_usd`, `volume_24h`, `txns`, `fdv`, `price_change`) and legacy filter param names are mapped to canonical search fields/params internally.
+- Added `cursor` to `PoolListOptions`, `PoolFilterOptions`, `TopTokensOptions`, and `TokenFilterOptions`.
+
+### Removed
+- Dead types from the old top-tokens response: `TopToken`, `TopTokenTimeMetrics`, `TopTokensPaginatedResponse`.
+
+### Added
+- New TypeScript interfaces: `SearchPool`, `PoolTokenRef`, `PoolSearchResponse`, `SearchToken`, `TokenSearchResponse`. `FilteredPool`/`FilteredToken` and `PoolFilterPaginatedResponse`/`TokenFilterPaginatedResponse` are retained as back-compat aliases.
+
 ## 1.5.0 (2026-03-31)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,9 +13,23 @@ Developed and maintained by [Coinpaprika](https://coinpaprika.com).
 npm install dexpaprika-sdk
 ```
 
-## Important: API v1.3.0 Migration Notice
+## Important: migration notices
 
-**⚠️ Breaking Changes in v1.4.0**: The global pools endpoint has been deprecated. All pool queries now require a network specification.
+**Breaking changes in v1.6.0**: The API removed the per-network list/filter REST endpoints (now HTTP 410). `pools.listByNetwork()`, `pools.filter()`, `tokens.getTop()`, and `tokens.filter()` now call the unified search endpoints and return the cursor-paginated shape `{ results, has_next_page, next_cursor }`. Method signatures are unchanged; legacy sort/filter values are mapped internally. See the [CHANGELOG](./CHANGELOG.md) for field-level details.
+
+```javascript
+// Cursor pagination (page is ignored on search endpoints):
+const first = await client.pools.listByNetwork('ethereum', { limit: 10 });
+console.log(first.results, first.has_next_page);
+if (first.next_cursor) {
+  const next = await client.pools.listByNetwork('ethereum', {
+    limit: 10,
+    cursor: first.next_cursor
+  });
+}
+```
+
+**Breaking changes in v1.4.0**: The global pools endpoint has been deprecated. All pool queries now require a network specification.
 
 ```javascript
 // ❌ OLD (deprecated) - will throw DeprecatedEndpointError:
@@ -38,12 +52,12 @@ const client = new DexPaprikaClient();
 const networks = await client.networks.list();
 console.log(networks);
 
-// Get top pools on Ethereum
+// Get top pools on Ethereum (cursor-paginated search endpoint)
 const pools = await client.pools.listByNetwork('ethereum', {
-  page: 0,
   limit: 10
 });
-console.log(pools.pools);
+console.log(pools.results);            // pool rows
+console.log(pools.has_next_page, pools.next_cursor); // pagination
 
 // Search for tokens
 const results = await client.search.search('bitcoin');
@@ -59,12 +73,11 @@ import { DexPaprikaClient } from 'dexpaprika-sdk';
 
 const client = new DexPaprikaClient();
 
-// Get top pools with pagination and sorting
+// Get top pools with sorting and cursor pagination
 const pools = await client.pools.listByNetwork('ethereum', {
-  page: 0,
   limit: 10,
   sort: 'desc',
-  orderBy: 'volume_usd'
+  orderBy: 'volume_usd_24h' // legacy 'volume_usd' is also accepted and mapped
 });
 
 // Get pool details with options
@@ -156,13 +169,22 @@ const dexes = await client.dexes.listByNetwork('ethereum', {
 ### Pools & Transactions
 
 ```js
-// Top pools on Ethereum with pagination
+// Top pools on Ethereum (cursor-paginated; read results / has_next_page / next_cursor)
 const topPools = await client.pools.listByNetwork('ethereum', {
-  page: 0,
   limit: 10,
   sort: 'desc',
-  orderBy: 'volume_usd'
+  orderBy: 'volume_usd_24h'
 });
+console.log(`Got ${topPools.results.length} pools`);
+
+// Fetch the next page with the returned cursor
+if (topPools.has_next_page && topPools.next_cursor) {
+  const nextPage = await client.pools.listByNetwork('ethereum', {
+    limit: 10,
+    cursor: topPools.next_cursor
+  });
+  console.log(`Next page: ${nextPage.results.length} pools`);
+}
 
 // Top pools on different networks
 const solanaPools = await client.pools.listByNetwork('solana', { limit: 5 });
@@ -227,26 +249,36 @@ const pools = await client.tokens.getPools(
 
 ### Pool Filtering
 
+Backed by the unified `/networks/{network}/pools/search` endpoint. Results come
+back as `{ results, has_next_page, next_cursor }`; legacy `sortBy` values such as
+`volume_24h` are accepted and mapped to canonical fields.
+
 ```js
 // Find high-volume pools on Ethereum
 const filtered = await client.pools.filter('ethereum', {
   volume24hMin: 100000,
   txns24hMin: 50,
-  sortBy: 'volume_24h',
+  sortBy: 'volume_usd_24h', // legacy 'volume_24h' also accepted
   sortDir: 'desc',
   limit: 10
 });
 console.log(`Found ${filtered.results.length} pools matching criteria`);
+// Next page: pass filtered.next_cursor as `cursor`
 ```
 
 ### Top Tokens & Token Filtering
 
+Both are backed by `/networks/{network}/tokens/search` and return
+`{ results, has_next_page, next_cursor }`. Token rows are flat: `address`,
+`volume_usd_24h`, `fdv_usd`, `txns_24h`, `price_change_percentage_24h`, etc.
+
 ```js
-// Get top tokens by volume
+// Get top tokens by 24h volume
 const topTokens = await client.tokens.getTop('ethereum', {
-  orderBy: 'volume_24h',
+  orderBy: 'volume_usd_24h', // legacy 'volume_24h' also accepted
   limit: 10
 });
+console.log(topTokens.results.map(t => t.address));
 
 // Filter tokens by criteria
 const filtered = await client.tokens.filter('ethereum', {

--- a/examples/basic-example.ts
+++ b/examples/basic-example.ts
@@ -18,25 +18,25 @@ async function main() {
     const stats = await client.utils.getStats();
     console.log(`Stats: ${stats.chains} chains, ${stats.pools} pools, ${stats.tokens} tokens`);
 
-    // Get top pools on Ethereum by volume (updated to use network-specific method)
+    // Get top pools on Ethereum by 24h volume (cursor-paginated pools/search)
     const poolsResp = await client.pools.listByNetwork('ethereum', {
-      page: 0,
       limit: 5,
       sort: 'desc',
-      orderBy: 'volume_usd'
+      orderBy: 'volume_usd_24h'
     });
     console.log('Top Ethereum pools:');
-    
-    // Display pool information with formatting
-    for (const pool of poolsResp.pools) {
-      const pair = pool.tokens.length < 2 ? 'Unknown' : 
-        formatPair(pool.tokens[0].symbol, pool.tokens[1].symbol);
-      console.log(`${pair}: ${formatVolume(pool.volume_usd)} on ${pool.dex_name}`);
+
+    // Display pool information with formatting. The pools/search endpoint returns
+    // lean token refs by default, so fall back to a short id when no symbol.
+    for (const pool of poolsResp.results) {
+      const label = (i: number) => pool.tokens[i].symbol ?? pool.tokens[i].id.slice(0, 6);
+      const pair = pool.tokens.length < 2 ? 'Unknown' : formatPair(label(0), label(1));
+      console.log(`${pair}: ${formatVolume(pool.volume_usd_24h ?? 0)} on ${pool.dex_name}`);
     }
 
     // Historical data for selected pool
-    if (poolsResp.pools.length) {
-      const pool = poolsResp.pools[0];
+    if (poolsResp.results.length) {
+      const pool = poolsResp.results[0];
       
       // Get data for the past week
       const weekAgo = new Date(lastWeek() * 1000).toISOString().split('T')[0];

--- a/examples/migration-example.ts
+++ b/examples/migration-example.ts
@@ -26,19 +26,18 @@ async function main() {
   console.log('2. Using the new network-specific approach:');
   try {
     const ethereumPools = await client.pools.listByNetwork('ethereum', {
-      page: 0,
       limit: 3,
       sort: 'desc',
-      orderBy: 'volume_usd'
+      orderBy: 'volume_usd_24h'
     });
-    console.log(`✅ Successfully fetched ${ethereumPools.pools.length} Ethereum pools`);
-    
+    console.log(`✅ Successfully fetched ${ethereumPools.results.length} Ethereum pools`);
+
     // Show multiple networks
     const solanaPools = await client.pools.listByNetwork('solana', { limit: 2 });
-    console.log(`✅ Successfully fetched ${solanaPools.pools.length} Solana pools`);
-    
+    console.log(`✅ Successfully fetched ${solanaPools.results.length} Solana pools`);
+
     const fantomPools = await client.pools.listByNetwork('fantom', { limit: 2 });
-    console.log(`✅ Successfully fetched ${fantomPools.pools.length} Fantom pools\n`);
+    console.log(`✅ Successfully fetched ${fantomPools.results.length} Fantom pools\n`);
   } catch (error) {
     console.error('Unexpected error:', error);
   }

--- a/examples/retry-cache-example.ts
+++ b/examples/retry-cache-example.ts
@@ -1,11 +1,6 @@
 // Retry and Cache Example
 import { DexPaprikaClient } from '../src';
 
-// Define a minimal type to avoid TypeScript errors
-interface PaginatedPoolResponse {
-  pools: { name?: string; length: number }[];
-}
-
 async function main() {
   try {
     // Create client with custom configuration
@@ -80,21 +75,21 @@ async function main() {
     
     // Get Ethereum pools (first request)
     console.time('Ethereum pools (first request)');
-    const ethPools = await client.pools.listByNetwork('ethereum', 0, 5) as PaginatedPoolResponse;
+    const ethPools = await client.pools.listByNetwork('ethereum', { limit: 5 });
     console.timeEnd('Ethereum pools (first request)');
-    console.log(`   - Found ${ethPools.pools.length} Ethereum pools`);
+    console.log(`   - Found ${ethPools.results.length} Ethereum pools`);
     console.log(`   - Cache size: ${client.cacheSize} entries`);
-    
+
     // Get Solana pools (different query, should hit API)
     console.time('Solana pools (different query)');
-    const solPools = await client.pools.listByNetwork('solana', 0, 5) as PaginatedPoolResponse;
+    const solPools = await client.pools.listByNetwork('solana', { limit: 5 });
     console.timeEnd('Solana pools (different query)');
-    console.log(`   - Found ${solPools.pools.length} Solana pools`);
+    console.log(`   - Found ${solPools.results.length} Solana pools`);
     console.log(`   - Cache size: ${client.cacheSize} entries`);
-    
+
     // Get Ethereum pools again (should use cache)
     console.time('Ethereum pools (cached)');
-    await client.pools.listByNetwork('ethereum', 0, 5);
+    await client.pools.listByNetwork('ethereum', { limit: 5 });
     console.timeEnd('Ethereum pools (cached)');
     
     console.log('\nExample completed successfully!');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "JavaScript SDK for the DexPaprika API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api/pools.ts
+++ b/src/api/pools.ts
@@ -3,7 +3,7 @@ import {
   PoolDetails,
   OHLCVRecord
 } from '../models/pools';
-import { PoolPaginatedResponse, PoolFilterPaginatedResponse } from '../models/base';
+import { PoolPaginatedResponse, PoolSearchResponse } from '../models/base';
 import {
   PoolListOptions,
   OHLCVOptions,
@@ -12,6 +12,7 @@ import {
   PoolFilterOptions,
 } from '../models/options';
 import { DeprecatedEndpointError } from '../utils/errors';
+import { mapPoolSortField, mapPoolFilterParams } from '../utils/searchParams';
 
 // Pools API implementation
 export class PoolsAPI extends BaseAPI {
@@ -46,28 +47,33 @@ export class PoolsAPI extends BaseAPI {
   }
   
   /**
-   * Get pools on a specific network with pagination and sorting.
-   * 
+   * Get pools on a specific network, cursor-paginated and sorted.
+   *
+   * Backed by the unified /networks/{network}/pools/search endpoint. Legacy
+   * `orderBy` values (e.g. 'volume_usd') are accepted and mapped to canonical
+   * sort fields; pass `cursor` for the next page (the response carries
+   * `has_next_page` and `next_cursor`).
+   *
    * @param networkId - Network identifier (e.g., 'ethereum', 'solana')
-   * @param options - Options for filtering, pagination and sorting
-   * @returns Paginated list of pools on the specified network
+   * @param options - Options for sorting, limit and cursor pagination
+   * @returns Search response with pool results on the specified network
    */
   async listByNetwork(
-    networkId: string, 
+    networkId: string,
     options?: PoolListOptions
-  ): Promise<PoolPaginatedResponse> {
+  ): Promise<PoolSearchResponse> {
     if (!networkId) {
       throw new Error('Network ID is required. Use \'ethereum\', \'solana\', \'fantom\', etc.');
     }
-    
+
     const params: Record<string, any> = {
-      page: options?.page ?? 0,
       limit: options?.limit ?? 10,
       sort: options?.sort ?? 'desc',
-      order_by: options?.orderBy ?? 'volume_usd'
+      order_by: mapPoolSortField(options?.orderBy),
     };
-    
-    return this._get<PoolPaginatedResponse>(`/networks/${networkId}/pools`, params);
+    if (options?.cursor) params.cursor = options.cursor;
+
+    return this._get<PoolSearchResponse>(`/networks/${networkId}/pools/search`, params);
   }
   
   /**
@@ -209,35 +215,42 @@ export class PoolsAPI extends BaseAPI {
   /**
    * Filter pools on a network by volume, liquidity, transactions, and creation date.
    *
+   * Backed by the unified /networks/{network}/pools/search endpoint. The request
+   * sends `order_by` (mapped from the legacy `sortBy`) and `sort` (direction),
+   * and is cursor-paginated (pass `cursor`; read `has_next_page`/`next_cursor`
+   * from the response). Legacy filter param names are mapped to canonical ones.
+   *
    * @param networkId - Network identifier (e.g., 'ethereum', 'solana')
-   * @param options - Filter criteria and pagination options
-   * @returns Filtered pools with pagination info
+   * @param options - Filter criteria and cursor pagination options
+   * @returns Search response with filtered pool results
    */
   async filter(
     networkId: string,
     options?: PoolFilterOptions
-  ): Promise<PoolFilterPaginatedResponse> {
+  ): Promise<PoolSearchResponse> {
     if (!networkId) {
       throw new Error('Network ID is required');
     }
 
     const params: Record<string, any> = {
-      page: options?.page ?? 1,
       limit: options?.limit ?? 10,
-      sort_by: options?.sortBy ?? 'volume_24h',
-      sort_dir: options?.sortDir ?? 'desc',
+      order_by: mapPoolSortField(options?.sortBy),
+      sort: options?.sortDir ?? 'desc',
     };
+    if (options?.cursor) params.cursor = options.cursor;
 
-    if (options?.volume24hMin !== undefined) params.volume_24h_min = options.volume24hMin;
-    if (options?.volume24hMax !== undefined) params.volume_24h_max = options.volume24hMax;
-    if (options?.volume7dMin !== undefined) params.volume_7d_min = options.volume7dMin;
-    if (options?.volume7dMax !== undefined) params.volume_7d_max = options.volume7dMax;
-    if (options?.liquidityUsdMin !== undefined) params.liquidity_usd_min = options.liquidityUsdMin;
-    if (options?.liquidityUsdMax !== undefined) params.liquidity_usd_max = options.liquidityUsdMax;
-    if (options?.txns24hMin !== undefined) params.txns_24h_min = options.txns24hMin;
-    if (options?.createdAfter !== undefined) params.created_after = options.createdAfter;
-    if (options?.createdBefore !== undefined) params.created_before = options.createdBefore;
+    const filters: Record<string, any> = {};
+    if (options?.volume24hMin !== undefined) filters.volume_24h_min = options.volume24hMin;
+    if (options?.volume24hMax !== undefined) filters.volume_24h_max = options.volume24hMax;
+    if (options?.volume7dMin !== undefined) filters.volume_7d_min = options.volume7dMin;
+    if (options?.volume7dMax !== undefined) filters.volume_7d_max = options.volume7dMax;
+    if (options?.liquidityUsdMin !== undefined) filters.liquidity_usd_min = options.liquidityUsdMin;
+    if (options?.liquidityUsdMax !== undefined) filters.liquidity_usd_max = options.liquidityUsdMax;
+    if (options?.txns24hMin !== undefined) filters.txns_24h_min = options.txns24hMin;
+    if (options?.createdAfter !== undefined) filters.created_after = options.createdAfter;
+    if (options?.createdBefore !== undefined) filters.created_before = options.createdBefore;
+    Object.assign(params, mapPoolFilterParams(filters));
 
-    return this._get<PoolFilterPaginatedResponse>(`/networks/${networkId}/pools/filter`, params);
+    return this._get<PoolSearchResponse>(`/networks/${networkId}/pools/search`, params);
   }
 }

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -1,12 +1,12 @@
 import { BaseAPI } from './base';
 import {
   TokenDetails,
-  TopTokensPaginatedResponse,
-  TokenFilterPaginatedResponse,
+  TokenSearchResponse,
   TokenPrice,
 } from '../models/tokens';
 import { PoolPaginatedResponse } from '../models/base';
 import { TokenPoolsOptions, TopTokensOptions, TokenFilterOptions } from '../models/options';
+import { mapTokenSortField, mapTokenFilterParams } from '../utils/searchParams';
 
 /**
  * API service for token-related endpoints.
@@ -55,25 +55,30 @@ export class TokensAPI extends BaseAPI {
   }
 
   /**
-   * Get top tokens on a network ranked by volume, price, liquidity, or other metrics.
+   * Get top tokens on a network ranked by volume, liquidity, or other metrics.
+   *
+   * Backed by the unified /networks/{network}/tokens/search endpoint. Legacy
+   * `orderBy` values (e.g. 'volume_24h') are accepted and mapped to canonical
+   * sort fields; the endpoint is cursor-paginated (pass `cursor`; read
+   * `has_next_page`/`next_cursor` from the response).
    *
    * @param networkId - Network ID (e.g., "ethereum", "solana")
-   * @param options - Pagination and sorting options
-   * @returns Top tokens with pagination info
+   * @param options - Sorting, limit and cursor pagination options
+   * @returns Search response with token results
    */
   async getTop(
     networkId: string,
     options?: TopTokensOptions
-  ): Promise<TopTokensPaginatedResponse> {
+  ): Promise<TokenSearchResponse> {
     const params: Record<string, any> = {
-      page: options?.page ?? 1,
       limit: options?.limit ?? 10,
-      order_by: options?.orderBy ?? 'volume_24h',
+      order_by: mapTokenSortField(options?.orderBy),
       sort: options?.sort ?? 'desc',
     };
+    if (options?.cursor) params.cursor = options.cursor;
 
-    return this._get<TopTokensPaginatedResponse>(
-      `/networks/${networkId}/tokens/top`,
+    return this._get<TokenSearchResponse>(
+      `/networks/${networkId}/tokens/search`,
       params
     );
   }
@@ -81,37 +86,38 @@ export class TokensAPI extends BaseAPI {
   /**
    * Filter tokens on a network by volume, liquidity, FDV, transactions, and creation date.
    *
+   * Backed by the unified /networks/{network}/tokens/search endpoint. The request
+   * sends `order_by` (mapped from the legacy `sortBy`) and `sort` (direction),
+   * and is cursor-paginated (pass `cursor`; read `has_next_page`/`next_cursor`
+   * from the response). Legacy filter param names are mapped to canonical ones.
+   *
    * @param networkId - Network ID (e.g., "ethereum", "solana")
-   * @param options - Filter criteria and pagination options
-   * @returns Filtered tokens with pagination info
+   * @param options - Filter criteria and cursor pagination options
+   * @returns Search response with filtered token results
    */
   async filter(
     networkId: string,
     options?: TokenFilterOptions
-  ): Promise<TokenFilterPaginatedResponse> {
+  ): Promise<TokenSearchResponse> {
     const params: Record<string, any> = {
-      page: options?.page ?? 1,
       limit: options?.limit ?? 10,
-      sort_by: options?.sortBy ?? 'volume_24h',
-      sort_dir: options?.sortDir ?? 'desc',
+      order_by: mapTokenSortField(options?.sortBy),
+      sort: options?.sortDir ?? 'desc',
     };
+    if (options?.cursor) params.cursor = options.cursor;
 
-    if (options?.volume24hMin !== undefined) params.volume_24h_min = options.volume24hMin;
-    if (options?.volume24hMax !== undefined) params.volume_24h_max = options.volume24hMax;
-    if (options?.liquidityUsdMin !== undefined) params.liquidity_usd_min = options.liquidityUsdMin;
-    if (options?.fdvMin !== undefined) params.fdv_min = options.fdvMin;
-    if (options?.fdvMax !== undefined) params.fdv_max = options.fdvMax;
-    if (options?.txns24hMin !== undefined) params.txns_24h_min = options.txns24hMin;
-    if (options?.createdAfter !== undefined) params.created_after = options.createdAfter;
-    if (options?.createdBefore !== undefined) params.created_before = options.createdBefore;
+    const filters: Record<string, any> = {};
+    if (options?.volume24hMin !== undefined) filters.volume_24h_min = options.volume24hMin;
+    if (options?.volume24hMax !== undefined) filters.volume_24h_max = options.volume24hMax;
+    if (options?.liquidityUsdMin !== undefined) filters.liquidity_usd_min = options.liquidityUsdMin;
+    if (options?.fdvMin !== undefined) filters.fdv_min = options.fdvMin;
+    if (options?.fdvMax !== undefined) filters.fdv_max = options.fdvMax;
+    if (options?.txns24hMin !== undefined) filters.txns_24h_min = options.txns24hMin;
+    if (options?.createdAfter !== undefined) filters.created_after = options.createdAfter;
+    if (options?.createdBefore !== undefined) filters.created_before = options.createdBefore;
+    Object.assign(params, mapTokenFilterParams(filters));
 
-    // The token filter endpoint returns its rows under a "data" key. Remap to
-    // "results" so the response matches the other filter endpoints' shape.
-    const raw = await this._get<{
-      data?: TokenFilterPaginatedResponse['results'];
-      page_info: TokenFilterPaginatedResponse['page_info'];
-    }>(`/networks/${networkId}/tokens/filter`, params);
-    return { results: raw.data ?? [], page_info: raw.page_info };
+    return this._get<TokenSearchResponse>(`/networks/${networkId}/tokens/search`, params);
   }
 
   /**

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -23,14 +23,19 @@ export interface DexPaginatedResponse {
   page_info: PageInfo;
 }
 
-// pool list response
+// pool list response (still-valid /dexes/{dex}/pools and /tokens/{addr}/pools)
 export interface PoolPaginatedResponse {
   pools: Pool[];
   page_info: PageInfo;
 }
 
-// pool filter response (uses 'results' key)
-export interface PoolFilterPaginatedResponse {
+// Response from the cursor-paginated /networks/{network}/pools/search endpoint.
+// Used by both pools.listByNetwork() and pools.filter().
+export interface PoolSearchResponse {
   results: FilteredPool[];
-  page_info: PageInfo;
+  has_next_page?: boolean;
+  next_cursor?: string | null;
 }
+
+// Back-compat alias for the previous pool filter response type.
+export type PoolFilterPaginatedResponse = PoolSearchResponse;

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -20,6 +20,8 @@ export interface SortOptions extends PaginationOptions {
   sort?: 'asc' | 'desc';
   /** Field to sort by */
   orderBy?: string;
+  /** Cursor for the next page (cursor-paginated search endpoints) */
+  cursor?: string;
 }
 
 /**
@@ -77,11 +79,13 @@ export interface OHLCVOptions {
  * Options for pool filtering endpoint
  */
 export interface PoolFilterOptions {
-  /** Page number (1-indexed) */
+  /** @deprecated The search endpoint is cursor-paginated; `page` is ignored. Use `cursor`. */
   page?: number;
+  /** Cursor for the next page (from the response's `next_cursor`) */
+  cursor?: string;
   /** Number of results per page (max 100) */
   limit?: number;
-  /** Field to sort by */
+  /** Field to sort by (legacy values such as 'volume_24h' are mapped) */
   sortBy?: string;
   /** Sort direction */
   sortDir?: 'asc' | 'desc';
@@ -109,11 +113,13 @@ export interface PoolFilterOptions {
  * Options for top tokens endpoint
  */
 export interface TopTokensOptions {
-  /** Page number (1-indexed) */
+  /** @deprecated The search endpoint is cursor-paginated; `page` is ignored. Use `cursor`. */
   page?: number;
+  /** Cursor for the next page (from the response's `next_cursor`) */
+  cursor?: string;
   /** Number of results per page (max 100) */
   limit?: number;
-  /** Field to order by (e.g., "volume_24h", "price_usd", "liquidity_usd") */
+  /** Field to order by (legacy values such as "volume_24h" are mapped) */
   orderBy?: string;
   /** Sort direction */
   sort?: 'asc' | 'desc';
@@ -123,11 +129,13 @@ export interface TopTokensOptions {
  * Options for token filtering endpoint
  */
 export interface TokenFilterOptions {
-  /** Page number (1-indexed) */
+  /** @deprecated The search endpoint is cursor-paginated; `page` is ignored. Use `cursor`. */
   page?: number;
+  /** Cursor for the next page (from the response's `next_cursor`) */
+  cursor?: string;
   /** Number of results per page (max 100) */
   limit?: number;
-  /** Field to sort by */
+  /** Field to sort by (legacy values such as 'volume_24h' are mapped) */
   sortBy?: string;
   /** Sort direction */
   sortDir?: 'asc' | 'desc';

--- a/src/models/pools.ts
+++ b/src/models/pools.ts
@@ -38,28 +38,43 @@ export interface Pool {
   liquidity_usd?: number;
 }
 
-// Pool from the filter endpoint (/networks/{id}/pools/filter).
-// Unlike the list endpoint, the filter endpoint returns timeframe-split volume
-// (volume_usd_24h/_7d/_30d) and liquidity_usd, and no flat volume_usd.
-export interface FilteredPool {
+// Token reference embedded in a pools/search result. By default the endpoint
+// returns only id/chain/has_image; name, symbol and decimals are populated when
+// the pool is fetched with detailed token info.
+export interface PoolTokenRef {
   id: string;
+  chain?: string;
+  has_image?: boolean;
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+}
+
+// Pool item from the unified search endpoint (/networks/{id}/pools/search).
+// Volume is timeframe-split (volume_usd_24h/_7d/_30d), price changes are
+// percentages, and the transaction count is transactions_24h.
+export interface SearchPool {
+  id: string; // pool address
+  chain: string;
   dex_id: string;
   dex_name: string;
-  chain: string;
-  tokens: Token[];
-  created_at?: string;
-  created_at_block_number?: number;
-  transactions?: number;
-  price_usd?: number;
+  fee?: number | null;
+  created_at: string;
+  created_at_block_number: number;
   volume_usd_24h?: number;
   volume_usd_7d?: number;
   volume_usd_30d?: number;
   liquidity_usd?: number;
-  last_price_change_usd_5m?: number | null;
-  last_price_change_usd_1h?: number | null;
-  last_price_change_usd_24h?: number | null;
-  fee?: number | null;
+  transactions_24h?: number;
+  price_usd?: number;
+  price_change_percentage_5m?: number | null;
+  price_change_percentage_1h?: number | null;
+  price_change_percentage_24h?: number | null;
+  tokens: PoolTokenRef[];
 }
+
+// Back-compat alias for the previous pools/filter item type.
+export type FilteredPool = SearchPool;
 
 // alias for backward compat
 export type PoolsResponse = PoolPaginatedResponse;

--- a/src/models/tokens.ts
+++ b/src/models/tokens.ts
@@ -152,42 +152,13 @@ export interface TokenTimeInterval {
   txns: number;
 }
 
-// Time interval metrics for top tokens (lighter version)
-export interface TopTokenTimeMetrics {
-  volume_usd: number;
-  txns: number;
-  last_price_usd_change?: number;
-  buys?: number;
-  sells?: number;
-}
-
-// Token from the top tokens endpoint
-export interface TopToken {
+// Token item from the unified search endpoint (/networks/{id}/tokens/search).
+// Flat shape: no name/symbol, no buys/sells, no pools-count, no nested
+// 24h/1h/5m objects.
+export interface SearchToken {
   address: string;
-  name: string;
-  symbol: string;
   chain: string;
-  decimals: number;
-  has_image?: boolean;
-  price_usd?: number;
-  fdv?: number;
-  liquidity_usd?: number;
-  pools?: number;
-  '24h'?: TopTokenTimeMetrics;
-  '1h'?: TopTokenTimeMetrics;
-  '5m'?: TopTokenTimeMetrics;
-}
-
-// Paginated response for top tokens
-export interface TopTokensPaginatedResponse {
-  tokens: TopToken[];
-  page_info: import('./base').PageInfo;
-}
-
-// Token from the filter endpoint
-export interface FilteredToken {
-  chain: string;
-  address: string;
+  created_at?: string;
   price_usd?: number;
   volume_usd_24h?: number;
   volume_usd_7d?: number;
@@ -195,14 +166,22 @@ export interface FilteredToken {
   liquidity_usd?: number;
   fdv_usd?: number;
   txns_24h?: number;
-  created_at?: string;
+  price_change_percentage_24h?: number;
 }
 
-// Paginated response for filtered tokens
-export interface TokenFilterPaginatedResponse {
-  results: FilteredToken[];
-  page_info: import('./base').PageInfo;
+// Back-compat alias for the previous tokens/filter item type.
+export type FilteredToken = SearchToken;
+
+// Response from the cursor-paginated /networks/{network}/tokens/search endpoint.
+// Used by both tokens.getTop() and tokens.filter().
+export interface TokenSearchResponse {
+  results: SearchToken[];
+  has_next_page?: boolean;
+  next_cursor?: string | null;
 }
+
+// Back-compat alias for the previous token filter response type.
+export type TokenFilterPaginatedResponse = TokenSearchResponse;
 
 // Token price from multi-prices endpoint
 export interface TokenPrice {

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -1,0 +1,118 @@
+// Shared, pure helpers for the unified search endpoints
+// (/networks/{network}/pools/search and /networks/{network}/tokens/search).
+//
+// The search endpoints return HTTP 400 on legacy sort-field values and legacy
+// filter param names, so every value/name coming from the public option types
+// (which stay backward-compatible) must be mapped to its canonical form here.
+
+// ---------------------------------------------------------------------------
+// Sort-field value mapping (legacy or canonical -> canonical order_by value).
+// ---------------------------------------------------------------------------
+
+// Pools: legacy aliases plus canonical pass-through. Unknown -> default.
+const POOL_SORT_FIELD_MAP: Record<string, string> = {
+  // legacy -> canonical
+  volume_usd: 'volume_usd_24h',
+  transactions: 'txns_24h',
+  last_price_change_usd_24h: 'price_change_percentage_24h',
+  volume_24h: 'volume_usd_24h',
+  volume_7d: 'volume_usd_7d',
+  volume_30d: 'volume_usd_30d',
+  liquidity: 'liquidity_usd',
+  // canonical pass-through
+  volume_usd_24h: 'volume_usd_24h',
+  volume_usd_7d: 'volume_usd_7d',
+  volume_usd_30d: 'volume_usd_30d',
+  liquidity_usd: 'liquidity_usd',
+  txns_24h: 'txns_24h',
+  created_at: 'created_at',
+  price_usd: 'price_usd',
+  price_change_percentage_24h: 'price_change_percentage_24h',
+};
+
+// Tokens: legacy aliases plus canonical pass-through. Unknown -> default.
+// Note: tokens/search returns 400 on price ordering, so price_usd folds to the
+// default volume_usd_24h.
+const TOKEN_SORT_FIELD_MAP: Record<string, string> = {
+  // legacy -> canonical
+  volume_24h: 'volume_usd_24h',
+  txns: 'txns_24h',
+  price_change: 'price_change_percentage_24h',
+  fdv: 'fdv_usd',
+  volume_7d: 'volume_usd_7d',
+  volume_30d: 'volume_usd_30d',
+  price_usd: 'volume_usd_24h',
+  // canonical pass-through
+  volume_usd_24h: 'volume_usd_24h',
+  volume_usd_7d: 'volume_usd_7d',
+  volume_usd_30d: 'volume_usd_30d',
+  liquidity_usd: 'liquidity_usd',
+  txns_24h: 'txns_24h',
+  fdv_usd: 'fdv_usd',
+  created_at: 'created_at',
+  price_change_percentage_24h: 'price_change_percentage_24h',
+};
+
+const DEFAULT_SORT_FIELD = 'volume_usd_24h';
+
+/**
+ * Map a pool sort field (legacy or canonical) to the canonical order_by value
+ * accepted by /networks/{network}/pools/search. Unknown or missing -> default.
+ */
+export function mapPoolSortField(value?: string): string {
+  if (!value) return DEFAULT_SORT_FIELD;
+  return POOL_SORT_FIELD_MAP[value] ?? DEFAULT_SORT_FIELD;
+}
+
+/**
+ * Map a token sort field (legacy or canonical) to the canonical order_by value
+ * accepted by /networks/{network}/tokens/search. Unknown or missing -> default.
+ */
+export function mapTokenSortField(value?: string): string {
+  if (!value) return DEFAULT_SORT_FIELD;
+  return TOKEN_SORT_FIELD_MAP[value] ?? DEFAULT_SORT_FIELD;
+}
+
+// ---------------------------------------------------------------------------
+// Filter param NAME mapping (legacy query param name -> canonical search param).
+// Unmapped names pass through unchanged.
+// ---------------------------------------------------------------------------
+
+const POOL_FILTER_PARAM_MAP: Record<string, string> = {
+  volume_24h_min: 'volume_usd_24h_min',
+  volume_24h_max: 'volume_usd_24h_max',
+  volume_7d_min: 'volume_usd_7d_min',
+  volume_7d_max: 'volume_usd_7d_max',
+};
+
+const TOKEN_FILTER_PARAM_MAP: Record<string, string> = {
+  volume_24h_min: 'volume_usd_24h_min',
+  volume_24h_max: 'volume_usd_24h_max',
+};
+
+function remapKeys(
+  params: Record<string, any>,
+  map: Record<string, string>
+): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const [key, value] of Object.entries(params)) {
+    out[map[key] ?? key] = value;
+  }
+  return out;
+}
+
+/**
+ * Rename legacy pool filter param names to the canonical pools/search names.
+ * Names not in the map (e.g. liquidity_usd_min, txns_24h_min) pass through.
+ */
+export function mapPoolFilterParams(params: Record<string, any>): Record<string, any> {
+  return remapKeys(params, POOL_FILTER_PARAM_MAP);
+}
+
+/**
+ * Rename legacy token filter param names to the canonical tokens/search names.
+ * Names not in the map (e.g. liquidity_usd_min, fdv_min) pass through.
+ */
+export function mapTokenFilterParams(params: Record<string, any>): Record<string, any> {
+  return remapKeys(params, TOKEN_FILTER_PARAM_MAP);
+}

--- a/tests/test-basic.ts
+++ b/tests/test-basic.ts
@@ -23,16 +23,15 @@ async function main() {
     });
     console.log(`Got ${dexes.dexes.length} ETH dexes`);
     
-    // Get some top pools on Ethereum (updated to use network-specific method)
+    // Get some top pools on Ethereum (cursor-paginated pools/search endpoint)
     const pools = await client.pools.listByNetwork('ethereum', {
-      page: 0,
       limit: 3
     });
-    console.log(`Got ${pools.pools.length} top pools on Ethereum`);
-    
-    if (pools.pools.length > 0) {
+    console.log(`Got ${pools.results.length} top pools on Ethereum`);
+
+    if (pools.results.length > 0) {
       // Check first pool details
-      const pool = pools.pools[0];
+      const pool = pools.results[0];
       console.log(`Testing pool: ${pool.id} on ${pool.chain}`);
       
       // Pool details

--- a/tests/test-migration.ts
+++ b/tests/test-migration.ts
@@ -2,6 +2,7 @@
  * Test migration from deprecated pools.list() to network-specific methods
  */
 
+/// <reference types="node" />
 import { DexPaprikaClient, DeprecatedEndpointError } from '../src';
 
 async function testMigration() {
@@ -27,7 +28,7 @@ async function testMigration() {
     // Test 2: Verify network-specific method works
     console.log('\n2. Testing network-specific pools.listByNetwork() method...');
     const ethereumPools = await client.pools.listByNetwork('ethereum', { limit: 5 });
-    console.log(`✅ Successfully fetched ${ethereumPools.pools.length} Ethereum pools`);
+    console.log(`✅ Successfully fetched ${ethereumPools.results.length} Ethereum pools`);
     
     // Test 3: Test multiple networks
     console.log('\n3. Testing multiple networks...');
@@ -36,7 +37,7 @@ async function testMigration() {
     for (const network of networks) {
       try {
         const pools = await client.pools.listByNetwork(network, { limit: 3 });
-        console.log(`✅ ${network}: ${pools.pools.length} pools`);
+        console.log(`✅ ${network}: ${pools.results.length} pools`);
       } catch (error: any) {
         console.log(`⚠️  ${network}: ${error.message}`);
       }

--- a/tests/test-new-endpoints.ts
+++ b/tests/test-new-endpoints.ts
@@ -1,8 +1,9 @@
+/// <reference types="node" />
 import { DexPaprikaClient } from '../src';
 
 // Test all 4 new endpoints against the live API
 async function main() {
-  console.log("Testing new DexPaprika SDK endpoints (v1.5.0)\n");
+  console.log("Testing new DexPaprika SDK endpoints (v1.6.0)\n");
   const client = new DexPaprikaClient();
   let passed = 0;
   let failed = 0;
@@ -25,11 +26,11 @@ async function main() {
       limit: 5,
     });
     if (!result.results || result.results.length === 0) throw new Error('No results');
-    if (!result.page_info) throw new Error('No page_info');
+    if (typeof result.has_next_page !== 'boolean') throw new Error('No has_next_page');
     const pool = result.results[0];
     if (!pool.id) throw new Error('Pool missing id');
     if (!pool.tokens || pool.tokens.length === 0) throw new Error('Pool missing tokens');
-    console.log(`   Got ${result.results.length} filtered pools, first: ${pool.tokens.map(t => t.symbol).join('/')}`);
+    console.log(`   Got ${result.results.length} filtered pools, first: ${pool.tokens.map(t => t.symbol ?? t.id.slice(0, 6)).join('/')}`);
   });
 
   await test('pools.filter - multiple params', async () => {
@@ -47,12 +48,12 @@ async function main() {
   // 2. Top Tokens
   await test('tokens.getTop - basic', async () => {
     const result = await client.tokens.getTop('ethereum', { limit: 5 });
-    if (!result.tokens || result.tokens.length === 0) throw new Error('No tokens');
-    if (!result.page_info) throw new Error('No page_info');
-    const token = result.tokens[0];
+    if (!result.results || result.results.length === 0) throw new Error('No tokens');
+    if (typeof result.has_next_page !== 'boolean') throw new Error('No has_next_page');
+    const token = result.results[0];
     if (!token.address) throw new Error('Token missing address');
-    if (!token.symbol) throw new Error('Token missing symbol');
-    console.log(`   Top token: ${token.symbol} at $${token.price_usd?.toFixed(4)}`);
+    if (!token.chain) throw new Error('Token missing chain');
+    console.log(`   Top token: ${token.address.substring(0, 10)}... at $${token.price_usd?.toFixed(4)}`);
   });
 
   await test('tokens.getTop - with sort', async () => {
@@ -61,8 +62,8 @@ async function main() {
       sort: 'asc',
       limit: 3,
     });
-    if (!result.tokens) throw new Error('No tokens');
-    console.log(`   Got ${result.tokens.length} tokens (asc sort)`);
+    if (!result.results) throw new Error('No tokens');
+    console.log(`   Got ${result.results.length} tokens (asc sort)`);
   });
 
   // 3. Token Filter
@@ -72,7 +73,7 @@ async function main() {
       limit: 5,
     });
     if (!result.results || result.results.length === 0) throw new Error('No results');
-    if (!result.page_info) throw new Error('No page_info');
+    if (typeof result.has_next_page !== 'boolean') throw new Error('No has_next_page');
     const token = result.results[0];
     if (!token.address) throw new Error('Token missing address');
     if (!token.chain) throw new Error('Token missing chain');
@@ -127,7 +128,7 @@ async function main() {
 
   await test('existing: pools.listByNetwork', async () => {
     const pools = await client.pools.listByNetwork('ethereum', { limit: 2 });
-    if (pools.pools.length === 0) throw new Error('No pools');
+    if (pools.results.length === 0) throw new Error('No pools');
   });
 
   await test('existing: tokens.getDetails', async () => {

--- a/tests/test-real-world.ts
+++ b/tests/test-real-world.ts
@@ -51,19 +51,17 @@ async function realWorldTest() {
     // Get Ethereum pools (different endpoint)
     console.time('  Ethereum pools');
     const ethPools = await client.pools.listByNetwork('ethereum', {
-      page: 0,
       limit: 3
     });
     console.timeEnd('  Ethereum pools');
-    
-    if (ethPools.pools.length > 0) {
-      console.log(`  Top Ethereum pool: ${ethPools.pools[0].dex_name}`);
+
+    if (ethPools.results.length > 0) {
+      console.log(`  Top Ethereum pool: ${ethPools.results[0].dex_name}`);
     }
-    
+
     // Get the same pools again (should be cached)
     console.time('  Ethereum pools (cached)');
     await client.pools.listByNetwork('ethereum', {
-      page: 0,
       limit: 3
     });
     console.timeEnd('  Ethereum pools (cached)');


### PR DESCRIPTION
DexPaprika removed four REST endpoints (HTTP 410): `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, `/networks/{network}/tokens/filter`. The network-pools, pool-filter, top-tokens, and token-filter methods were erroring.

## Fix

Repoint all four to the unified search endpoints (method names + signatures unchanged for back-compat):

- network pools, pool filter -> `/networks/{network}/pools/search`
- top tokens, token filter -> `/networks/{network}/tokens/search`

A shared helper normalizes legacy sort-field values (`volume_usd` -> `volume_usd_24h`, `transactions` -> `txns_24h`, `last_price_change_usd_24h` -> `price_change_percentage_24h`, ...) and legacy filter param names (`volume_24h_min` -> `volume_usd_24h_min`, ...). The search endpoints **400** on the old names, so this mapping is required; the filter methods now send `order_by` + `sort`. Token sort by price falls back to volume (the token search rejects price ordering).

Responses are cursor-paginated: rows under `results` with `has_next_page` + `next_cursor` (no `page_info`); models use the new field names (`id` not `address` for pools, `transactions_24h`, `price_change_percentage_24h`, `fdv_usd`, ...). The new flat token shape has no name/symbol/buys/sells, so token models reflect what the API returns. Legacy params are still accepted; `page` is kept in signatures but no longer sent (an optional `cursor` is added).

## Verified

Live against api.dexpaprika.com: build and test suite pass; all four methods return real rows in both default and JSON usage; legacy sort values map instead of 400; zero em/en dashes.

## Release

After merge: `npm publish` (v1.6.0). The pre-existing deprecated global `/pools` list method is intentionally left to surface its deprecation (out of scope).