### PR TITLE
DeprecatedEndpointError surfaces the API replacement (1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the DexPaprika SDK will be documented in this file.
 
+## 1.6.1 (2026-07-01)
+
+### Changed
+- **`DeprecatedEndpointError` now surfaces the API replacement**: on an error whose body carries a `replacement` field, the thrown error includes the API's own message and points at the real replacement path (not just the hardcoded `/pools` alternative), and exposes `.replacement` / `.apiMessage` accessors. Generic across any error status carrying a `replacement`.
+
 ## 1.6.0 (2026-06-30)
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-sdk",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "JavaScript SDK for the DexPaprika API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -39,19 +39,49 @@ export class BaseAPI {
       // Handle HTTP errors
       if (error.response) {
         const status = error.response.status;
-        const message = error.response.data?.error || error.response.data?.message || 'Unknown API error';
-        
-        // Handle deprecated endpoint (410 Gone)
+        const data = error.response.data;
+
+        // Parse the error body defensively: it may not be JSON, or may lack
+        // these fields. Anything unexpected falls back to prior behavior.
+        const bodyIsObject = data !== null && typeof data === 'object';
+        const replacement: string | undefined =
+          bodyIsObject && typeof data.replacement === 'string' && data.replacement.trim() !== ''
+            ? data.replacement
+            : undefined;
+        const apiMessage: string | undefined = bodyIsObject
+          ? (data.error || data.message)
+          : undefined;
+        const message = apiMessage || 'Unknown API error';
+
+        // Generic, self-documenting deprecation handling: ANY non-2xx whose
+        // body carries a "replacement" hint is surfaced as a
+        // DeprecatedEndpointError that includes both the API's message and the
+        // exact replacement path. Not limited to 410 or specific endpoints, so
+        // future deprecations document themselves without an SDK change.
+        if (replacement) {
+          if (endpoint === '/pools') {
+            // Keep the /pools client-side special case wording, but still
+            // attach the API's message and replacement path for callers.
+            throw new DeprecatedEndpointError(
+              '/pools',
+              'network-specific endpoints like client.pools.listByNetwork(\'ethereum\')',
+              { replacement, apiMessage }
+            );
+          }
+          throw new DeprecatedEndpointError(endpoint, replacement, { replacement, apiMessage });
+        }
+
+        // Handle deprecated endpoint (410 Gone) with no replacement in body.
         if (status === 410) {
           if (endpoint === '/pools') {
             throw new DeprecatedEndpointError(
-              '/pools', 
+              '/pools',
               'network-specific endpoints like client.pools.listByNetwork(\'ethereum\')'
             );
           }
           throw new DeprecatedEndpointError(endpoint, 'check API documentation for alternatives');
         }
-        
+
         // Handle not found errors with context
         if (status === 404) {
           if (message.toLowerCase().includes('network')) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -78,7 +78,12 @@ export class DeprecatedEndpointError extends DexPaprikaError {
 
     // Surface the API's own deprecation message first, when it sent one.
     if (apiMessage) {
-      const trimmed = apiMessage.trim().replace(/[.:;\s]+$/, '');
+      // Strip trailing sentence punctuation and whitespace without a
+      // backtracking regex (ReDoS-safe) and without trimEnd (ES2019+).
+      let trimmed = apiMessage.trim();
+      while (trimmed.length > 0 && '.:; \t\n\r\f\v'.indexOf(trimmed[trimmed.length - 1]) !== -1) {
+        trimmed = trimmed.slice(0, -1);
+      }
       if (trimmed) {
         parts.push(`${trimmed}.`);
       }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -46,15 +46,60 @@ export class ApiError extends DexPaprikaError {
 }
 
 /**
- * Error thrown when trying to use a deprecated endpoint
+ * Optional deprecation hints surfaced by the API response body.
+ */
+export interface DeprecationDetails {
+  /** Replacement path advertised by the API (e.g. "/networks/:network/pools/search"). */
+  replacement?: string;
+  /** Raw deprecation message from the API response body (e.g. "endpoint removed"). */
+  apiMessage?: string;
+}
+
+/**
+ * Error thrown when trying to use a deprecated endpoint.
+ *
+ * When the API response body carries a "replacement" hint, it is surfaced on
+ * the {@link DeprecatedEndpointError.replacement} field and folded into the
+ * error message, so future deprecations self-document without an SDK change.
  */
 export class DeprecatedEndpointError extends DexPaprikaError {
-  constructor(endpoint: string, alternative: string) {
-    super(
-      `The ${endpoint} endpoint has been deprecated and removed. ` +
-      `Please use ${alternative} instead. ` +
-      `For more information, visit: https://docs.dexpaprika.com/changelog/changelog`
-    );
+  /** The deprecated endpoint that was called. */
+  public readonly endpoint: string;
+  /** Human-facing suggestion for what to use instead. */
+  public readonly alternative: string;
+  /** Replacement path advertised by the API response body, when present. */
+  public readonly replacement?: string;
+  /** Raw deprecation message from the API response body, when present. */
+  public readonly apiMessage?: string;
+
+  constructor(endpoint: string, alternative: string, details: DeprecationDetails = {}) {
+    const { replacement, apiMessage } = details;
+    const parts: string[] = [];
+
+    // Surface the API's own deprecation message first, when it sent one.
+    if (apiMessage) {
+      const trimmed = apiMessage.trim().replace(/[.:;\s]+$/, '');
+      if (trimmed) {
+        parts.push(`${trimmed}.`);
+      }
+    }
+
+    parts.push(`The ${endpoint} endpoint has been deprecated and removed.`);
+    parts.push(`Please use ${alternative} instead.`);
+
+    // Point at the exact path the API advertised, if it differs from the
+    // human-facing suggestion above (avoids repeating it verbatim).
+    if (replacement && replacement !== alternative) {
+      parts.push(`API replacement: ${replacement}.`);
+    }
+
+    parts.push('For more information, visit: https://docs.dexpaprika.com/changelog/changelog');
+
+    super(parts.join(' '));
     this.name = 'DeprecatedEndpointError';
+    this.endpoint = endpoint;
+    this.alternative = alternative;
+    this.replacement = replacement;
+    this.apiMessage = apiMessage;
   }
 } 


### PR DESCRIPTION
The 410 branch now reads the body's `replacement` and points ANY removed endpoint at the real replacement path (previously only `/pools` got a specific hint); the error also folds in the API message and exposes `.replacement`/`.apiMessage`. Generic across statuses; backward-compatible constructor. Version 1.6.0 -> 1.6.1. tsc + tests pass. Publish after merge: `npm publish`.