### PR TITLE
fix: migrate tokens.getPools to /pools/search (token-pools endpoint removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the DexPaprika SDK will be documented in this file.
 - The DexPaprika API removed `GET /networks/{network}/tokens/{address}/pools` (now HTTP 410). `tokens.getPools()` now calls the unified `/networks/{network}/pools/search` endpoint with its new `token_address` parameter.
 - `tokens.getPools()` returns the cursor-paginated search shape `{ results, has_next_page, next_cursor }` instead of `{ pools, page_info }`. Read the next page from `next_cursor` and pass it back via `cursor` (`page` is ignored).
 - The token filter is network-scoped only: the cross-network `/pools/search` endpoint accepts `token_address` but silently ignores it, so a network is always required.
-- `TokenPoolsOptions.pairWith` is deprecated and ignored: `/pools/search` has no pair filter, and repeating `token_address` is last-wins on the API side, not a pair filter. Filter the returned pools client-side by their `tokens` field to match a pair.
+- `TokenPoolsOptions.pairWith` is deprecated and ignored: `/pools/search` has no pair filter. Repeating `token_address` does not act as a pair filter; the API uses only one of the values (not guaranteed by order). Filter the returned pools client-side by their `tokens` field to match a pair.
 - The old `reorder` pair-perspective flip has no equivalent on `/pools/search`; metrics come from the pool's own perspective.
 - An unknown token address returns HTTP 200 with an empty result set, not an error. Legacy `orderBy` values (e.g. `volume_usd`) are mapped to canonical sort fields internally.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the DexPaprika SDK will be documented in this file.
 
+## 1.7.0 (2026-07-15)
+
+### Breaking Changes
+- The DexPaprika API removed `GET /networks/{network}/tokens/{address}/pools` (now HTTP 410). `tokens.getPools()` now calls the unified `/networks/{network}/pools/search` endpoint with its new `token_address` parameter.
+- `tokens.getPools()` returns the cursor-paginated search shape `{ results, has_next_page, next_cursor }` instead of `{ pools, page_info }`. Read the next page from `next_cursor` and pass it back via `cursor` (`page` is ignored).
+- The token filter is network-scoped only: the cross-network `/pools/search` endpoint accepts `token_address` but silently ignores it, so a network is always required.
+- `TokenPoolsOptions.pairWith` is deprecated and ignored: `/pools/search` has no pair filter, and repeating `token_address` is last-wins on the API side, not a pair filter. Filter the returned pools client-side by their `tokens` field to match a pair.
+- The old `reorder` pair-perspective flip has no equivalent on `/pools/search`; metrics come from the pool's own perspective.
+- An unknown token address returns HTTP 200 with an empty result set, not an error. Legacy `orderBy` values (e.g. `volume_usd`) are mapped to canonical sort fields internally.
+
 ## 1.6.1 (2026-07-01)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -87,15 +87,15 @@ const poolDetails = await client.pools.getDetails(
   { inversed: false }
 );
 
-// Get token pools with additional filters
+// Get pools that contain a token (network-scoped /pools/search filter,
+// cursor-paginated: rows under `results`, page via `cursor`)
 const tokenPools = await client.tokens.getPools(
   'ethereum',
   '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
   {
-    limit: 5, 
-    sort: 'desc', 
-    orderBy: 'volume_usd',
-    pairWith: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' // Filter for USDC pairs
+    limit: 5,
+    sort: 'desc',
+    orderBy: 'volume_usd_24h' // legacy 'volume_usd' is also accepted and mapped
   }
 );
 
@@ -233,17 +233,27 @@ const token = await client.tokens.getDetails(
   '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 );
 
-// Find WETH-USDC pools
+// Find WETH pools (network-scoped /pools/search with token_address).
+// Rows come back under `results`; page with `cursor` from `next_cursor`.
 const pools = await client.tokens.getPools(
   'ethereum', 
   '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
   {
-    page: 0,
     limit: 10,
     sort: 'desc',
-    orderBy: 'volume_usd',
-    pairWith: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' // USDC
+    orderBy: 'volume_usd_24h'
   }
+);
+for (const p of pools.results) {
+  console.log(p.id, p.volume_usd_24h);
+}
+
+// The removed /tokens/{address}/pools endpoint supported pair queries
+// (`pairWith`); /pools/search has no equivalent, so `pairWith` is deprecated
+// and ignored. To match a pair, filter client-side:
+const usdc = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const wethUsdcPools = pools.results.filter(
+  p => (p.tokens ?? []).some(t => t.id === usdc)
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "JavaScript SDK for the DexPaprika API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -4,9 +4,9 @@ import {
   TokenSearchResponse,
   TokenPrice,
 } from '../models/tokens';
-import { PoolPaginatedResponse } from '../models/base';
+import { PoolSearchResponse } from '../models/base';
 import { TokenPoolsOptions, TopTokensOptions, TokenFilterOptions } from '../models/options';
-import { mapTokenSortField, mapTokenFilterParams } from '../utils/searchParams';
+import { mapTokenSortField, mapPoolSortField, mapTokenFilterParams } from '../utils/searchParams';
 
 /**
  * API service for token-related endpoints.
@@ -24,32 +24,41 @@ export class TokensAPI extends BaseAPI {
   }
   
   /**
-   * Get a list of top liquidity pools for a specific token on a network.
-   * 
+   * Get a list of top liquidity pools that contain a specific token on a network.
+   *
+   * Backed by the unified /networks/{network}/pools/search endpoint with its
+   * `token_address` parameter (the old /tokens/{address}/pools endpoint was
+   * removed, HTTP 410). The filter is network-scoped only: the cross-network
+   * /pools/search endpoint accepts `token_address` but silently ignores it, so
+   * a network is always required here. Legacy `orderBy` values (e.g.
+   * 'volume_usd') are mapped to canonical sort fields; the endpoint is
+   * cursor-paginated (pass `cursor`; read `has_next_page`/`next_cursor` from
+   * the response; `page` is ignored). An unknown token address returns an
+   * empty result set, not an error.
+   *
    * @param networkId - Network ID (e.g., "ethereum", "solana")
    * @param tokenAddress - Token address or identifier
-   * @param options - Options for pagination, sorting, and filtering
-   * @returns Response containing a list of pools that include the specified token
+   * @param options - Sorting, limit and cursor pagination options
+   * @returns Search response with pools that contain the specified token
    */
   async getPools(
-    networkId: string, 
+    networkId: string,
     tokenAddress: string,
     options?: TokenPoolsOptions
-  ): Promise<PoolPaginatedResponse> {
-    // build params
-    const params: Record<string, any> = { 
-      page: options?.page ?? 0, 
-      limit: options?.limit ?? 10, 
-      sort: options?.sort ?? 'desc', 
-      order_by: options?.orderBy ?? 'volume_usd' 
+  ): Promise<PoolSearchResponse> {
+    const params: Record<string, any> = {
+      token_address: tokenAddress,
+      limit: options?.limit ?? 10,
+      sort: options?.sort ?? 'desc',
+      order_by: mapPoolSortField(options?.orderBy),
     };
-    
-    // add pair token if specified
-    if (options?.pairWith) params['address'] = options.pairWith;
-    
-    // get pools filtered by token
-    return this._get<PoolPaginatedResponse>(
-      `/networks/${networkId}/tokens/${tokenAddress}/pools`,
+    if (options?.cursor) params.cursor = options.cursor;
+
+    // Note: options.pairWith is deprecated and intentionally not sent.
+    // /pools/search has no pair filter and repeating token_address is
+    // last-wins on the API side, not a pair filter.
+    return this._get<PoolSearchResponse>(
+      `/networks/${networkId}/pools/search`,
       params
     );
   }

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -55,8 +55,9 @@ export class TokensAPI extends BaseAPI {
     if (options?.cursor) params.cursor = options.cursor;
 
     // Note: options.pairWith is deprecated and intentionally not sent.
-    // /pools/search has no pair filter and repeating token_address is
-    // last-wins on the API side, not a pair filter.
+    // /pools/search has no pair filter. Repeating token_address does not
+    // act as a pair filter; the API uses only one of the values (not
+    // guaranteed by order).
     return this._get<PoolSearchResponse>(
       `/networks/${networkId}/pools/search`,
       params

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -23,14 +23,14 @@ export interface DexPaginatedResponse {
   page_info: PageInfo;
 }
 
-// pool list response (still-valid /dexes/{dex}/pools and /tokens/{addr}/pools)
+// pool list response (still-valid /dexes/{dex}/pools)
 export interface PoolPaginatedResponse {
   pools: Pool[];
   page_info: PageInfo;
 }
 
 // Response from the cursor-paginated /networks/{network}/pools/search endpoint.
-// Used by both pools.listByNetwork() and pools.filter().
+// Used by pools.listByNetwork(), pools.filter() and tokens.getPools().
 export interface PoolSearchResponse {
   results: FilteredPool[];
   has_next_page?: boolean;

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -38,7 +38,8 @@ export interface TokenPoolsOptions extends SortOptions {
   /**
    * @deprecated Ignored. The removed /tokens/{address}/pools endpoint could
    * filter by a second token; the /pools/search endpoint that replaced it has
-   * no pair filter (repeating token_address is last-wins on the API side).
+   * no pair filter. Repeating token_address does not act as a pair filter;
+   * the API uses only one of the values (not guaranteed by order).
    * Filter the returned pools client-side to match a pair.
    */
   pairWith?: string;

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -35,8 +35,15 @@ export interface PoolListOptions extends SortOptions {
  * Options for getting token pools
  */
 export interface TokenPoolsOptions extends SortOptions {
-  /** Optional second token address to filter for pairs */
+  /**
+   * @deprecated Ignored. The removed /tokens/{address}/pools endpoint could
+   * filter by a second token; the /pools/search endpoint that replaced it has
+   * no pair filter (repeating token_address is last-wins on the API side).
+   * Filter the returned pools client-side to match a pair.
+   */
   pairWith?: string;
+  /** @deprecated The search endpoint is cursor-paginated; `page` is ignored. Use `cursor`. */
+  page?: number;
 }
 
 /**

--- a/tests/test-basic.ts
+++ b/tests/test-basic.ts
@@ -67,11 +67,11 @@ async function main() {
       const token = await client.tokens.getDetails('ethereum', weth);
       console.log(`WETH details: ${token.name} (${token.symbol})`);
       
+      // Token pools are served by the cursor-paginated /pools/search endpoint
       const wethPools = await client.tokens.getPools('ethereum', weth, {
-        page: 0,
         limit: 3
       });
-      console.log(`WETH is in ${wethPools.pools.length} pools`);
+      console.log(`WETH is in ${wethPools.results.length} pools`);
     } catch (err: any) {
       console.log(`Token error: ${err.message || 'Unknown error'}`);
     }

--- a/tests/test-migration.ts
+++ b/tests/test-migration.ts
@@ -69,7 +69,7 @@ async function testMigration() {
         throw new Error(`Pool ${pool.id} does not contain the requested token`);
       }
     }
-    console.log(`✅ ${wethPools.results.length} pools, all contain WETH`);
+    console.log(`PASS: ${wethPools.results.length} pools, all contain WETH`);
 
     if (!wethPools.has_next_page || !wethPools.next_cursor) {
       throw new Error('Expected a next cursor for WETH pools');
@@ -81,7 +81,7 @@ async function testMigration() {
     if (wethPage2.results.length === 0 || wethPage2.results[0].id === wethPools.results[0].id) {
       throw new Error('Cursor pagination did not advance to the next page');
     }
-    console.log('✅ Cursor pagination works for token pools');
+    console.log('PASS: Cursor pagination works for token pools');
 
     // Test 6: Show migration example
     console.log('\n6. Migration example:');

--- a/tests/test-migration.ts
+++ b/tests/test-migration.ts
@@ -56,8 +56,35 @@ async function testMigration() {
       }
     }
     
-    // Test 5: Show migration example
-    console.log('\n5. Migration example:');
+    // Test 5: tokens.getPools() now targets /pools/search with token_address
+    console.log('\n5. Testing tokens.getPools() against /pools/search...');
+    const weth = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+    const wethPools = await client.tokens.getPools('ethereum', weth, { limit: 3 });
+    if (wethPools.results.length === 0) {
+      throw new Error('Expected WETH pools, got an empty result set');
+    }
+    for (const pool of wethPools.results) {
+      const ids = (pool.tokens ?? []).map(t => t.id);
+      if (!ids.includes(weth)) {
+        throw new Error(`Pool ${pool.id} does not contain the requested token`);
+      }
+    }
+    console.log(`✅ ${wethPools.results.length} pools, all contain WETH`);
+
+    if (!wethPools.has_next_page || !wethPools.next_cursor) {
+      throw new Error('Expected a next cursor for WETH pools');
+    }
+    const wethPage2 = await client.tokens.getPools('ethereum', weth, {
+      limit: 3,
+      cursor: wethPools.next_cursor,
+    });
+    if (wethPage2.results.length === 0 || wethPage2.results[0].id === wethPools.results[0].id) {
+      throw new Error('Cursor pagination did not advance to the next page');
+    }
+    console.log('✅ Cursor pagination works for token pools');
+
+    // Test 6: Show migration example
+    console.log('\n6. Migration example:');
     console.log('❌ OLD (deprecated):');
     console.log('   const pools = await client.pools.list();');
     console.log('✅ NEW (required):');


### PR DESCRIPTION
## Why

The API removed `GET /networks/{network}/tokens/{token_address}/pools`. It now returns HTTP 410 with a `replacement` pointing at `/networks/:network/pools/search`, which gained a `token_address` query parameter that restricts results to pools containing that token on that network.

## What changed

- `tokens.getPools()` now calls `/networks/{network}/pools/search` with `token_address` and returns the cursor-paginated `PoolSearchResponse` (`{ results, has_next_page, next_cursor }`) instead of `{ pools, page_info }`, same shape as `pools.listByNetwork()` and `pools.filter()` since 1.6.0.
- Sort fields go through the existing `mapPoolSortField` helper (the search endpoint rejects legacy sort values with HTTP 400). `page` is deprecated and no longer sent; pass `cursor` from a response's `next_cursor` to page.
- `TokenPoolsOptions.pairWith` is deprecated and ignored: the search endpoint has no pair filter. Repeating `token_address` does not act as a pair filter; the API uses only one of the values (not guaranteed by order, verified live in both parameter orders). The old `reorder` pair-perspective flip has no equivalent either. README shows the client-side pair filter instead.
- JSDoc calls out that the filter is network-scoped only: the cross-network `/pools/search` accepts `token_address` but silently ignores it. A bogus address returns an empty result set, not an error.
- README examples updated, CHANGELOG entry added, version 1.7.0.

## Verification

All checked live against api.dexpaprika.com before pushing:

- The old endpoint returns `{"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}`.
- `GET /networks/ethereum/pools/search?token_address=0xc02aaa...756cc2&limit=3` returns 3 pools, every one containing WETH, with `has_next_page`/`next_cursor` and default `order_by=volume_usd_24h`.
- `tsc --noEmit` clean.
- `npm test`, `npm run test:migration` (includes the new live token-pools section: token containment on both cursor pages, cursor advances), `npm run verify`, `npm run verify:real` and the token-summary test all pass against the live API.

