### PR TITLE
Support the pools/search price-change windows (6h, 1h, 5m)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ All notable changes to the DexPaprika SDK will be documented in this file.
 
 ### Added
 - `pools.filter()` accepts price-change bounds on all four windows the pools/search endpoint supports: `priceChange24hMin`/`Max`, `priceChange6hMin`/`Max`, `priceChange1hMin`/`Max`, `priceChange5mMin`/`Max`. Values are percentages and negative bounds are meaningful, so `priceChange24hMax: -20` selects pools down at least a fifth on the day.
+- `tokens.filter()` accepts `priceChange24hMin`/`Max`. The 24h window is the one price-change bound `/networks/{network}/tokens/search` applies.
 - `price_change_percentage_6h`, `price_change_percentage_1h` and `price_change_percentage_5m` are accepted as pool sort fields (`orderBy`/`sortBy`) and reach the API unchanged.
 - `SearchPool` gained the `price_change_percentage_6h` field that pool rows already return.
-- `npm run test:endpoints` runs the live endpoint suite, which now pins the pools-only behaviour of the short windows.
+
+### Fixed
+- The test scripts run again. They invoked `ts-node`, which fails to start against the TypeScript 7 this SDK builds with, so `npm test` and every script chained after it died before executing anything. They now run under `tsx`, and `ts-node` is gone from the devDependencies.
 
 ### Notes
-- The 6h, 1h and 5m windows exist on pools only. `/networks/{network}/tokens/search` returns HTTP 400 for them and token rows carry no such field, so `TOKEN_SORT_FIELD_MAP` leaves them out on purpose and folds them to the default `volume_usd_24h`.
+- The three short windows, 6h, 1h and 5m, exist on pools only, and they fail two different ways on `/networks/{network}/tokens/search`: HTTP 400 as a sort value, silently ignored as a filter bound. `TOKEN_SORT_FIELD_MAP` leaves them out on purpose and folds them to the default `volume_usd_24h`, and `TokenFilterOptions` does not offer them. The 24h window works on both endpoints, for sorting and for filtering.
+- Both search endpoints answer 200 for query parameters they do not recognize and then ignore them, so a bound the SDK spelled wrong would come back as a full unfiltered page. `tests/test-search-params.ts` pins the exact parameter names the SDK puts on the wire without touching the network.
 
 ## 1.7.0 (2026-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the DexPaprika SDK will be documented in this file.
 
+## 1.8.0 (2026-08-07)
+
+### Added
+- `pools.filter()` accepts price-change bounds on all four windows the pools/search endpoint supports: `priceChange24hMin`/`Max`, `priceChange6hMin`/`Max`, `priceChange1hMin`/`Max`, `priceChange5mMin`/`Max`. Values are percentages and negative bounds are meaningful, so `priceChange24hMax: -20` selects pools down at least a fifth on the day.
+- `price_change_percentage_6h`, `price_change_percentage_1h` and `price_change_percentage_5m` are accepted as pool sort fields (`orderBy`/`sortBy`) and reach the API unchanged.
+- `SearchPool` gained the `price_change_percentage_6h` field that pool rows already return.
+- `npm run test:endpoints` runs the live endpoint suite, which now pins the pools-only behaviour of the short windows.
+
+### Notes
+- The 6h, 1h and 5m windows exist on pools only. `/networks/{network}/tokens/search` returns HTTP 400 for them and token rows carry no such field, so `TOKEN_SORT_FIELD_MAP` leaves them out on purpose and folds them to the default `volume_usd_24h`.
+
 ## 1.7.0 (2026-07-15)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -303,9 +303,18 @@ Pool sort fields: `volume_usd_24h`, `volume_usd_7d`, `volume_usd_30d`,
 `price_change_percentage_24h`, `price_change_percentage_6h`,
 `price_change_percentage_1h`, `price_change_percentage_5m`.
 
-The 6h, 1h and 5m windows are pools-only. The token search endpoint rejects them
-with HTTP 400 and token rows carry no such field, so `tokens.getTop()` and
-`tokens.filter()` do not take them.
+#### What the token endpoint does with the same windows
+
+The 24h window is common to both search endpoints. `tokens.filter()` takes
+`priceChange24hMin`/`Max`, and `price_change_percentage_24h` is a valid token
+sort field.
+
+Only the three short windows, 6h, 1h and 5m, are pools-only, and they fail in
+two different ways on `/networks/{network}/tokens/search`. As a sort value the
+endpoint returns HTTP 400. As a filter bound it returns 200 and ignores the
+parameter, which is indistinguishable from a wide filter unless you compare the
+page against an unfiltered one. So `tokens.getTop()` and `tokens.filter()` take
+neither, rather than passing along something that silently does nothing.
 
 ### Top Tokens & Token Filtering
 
@@ -325,6 +334,13 @@ console.log(topTokens.results.map(t => t.address));
 const filtered = await client.tokens.filter('ethereum', {
   volume24hMin: 100000,
   fdvMin: 1000000,
+  limit: 10
+});
+
+// Tokens up at least 20% on the day
+const gainers = await client.tokens.filter('ethereum', {
+  priceChange24hMin: 20,
+  sortBy: 'price_change_percentage_24h',
   limit: 10
 });
 ```
@@ -460,15 +476,30 @@ The SDK includes a comprehensive test suite to verify functionality:
 npm test
 
 # Run real-world API tests
-npx ts-node tests/test-real-world.ts
+npm run verify:real
+
+# Check the query the SDK builds for the search endpoints (offline, no network)
+npm run test:params
+
+# Hit the live search endpoints
+npm run test:endpoints
 
 # Run all tests sequentially
 npm run test:all
 ```
 
+The runner is `tsx`. It is a devDependency, so `npm ci` is all the setup there is.
+
 All test files are located in the `tests/` directory:
 - `test-basic.ts` - Basic API functionality tests
 - `test-real-world.ts` - Tests with actual API calls and simulated failures
+- `test-search-params.ts` - Offline checks on the query parameters the SDK sends
+  to `/pools/search` and `/tokens/search`. Both endpoints answer 200 for
+  parameters they do not recognize and ignore them, so a misspelled filter bound
+  looks like a successful wide filter over the wire. These checks read the params
+  off the client before the request goes out and need neither network nor market.
+- `test-new-endpoints.ts` - The live counterpart. Every filter check compares
+  against an unfiltered baseline rather than trusting the status code.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,37 @@ console.log(`Found ${filtered.results.length} pools matching criteria`);
 // Next page: pass filtered.next_cursor as `cursor`
 ```
 
+`pools.filter()` also takes price-change bounds on four windows: 24h, 6h, 1h and
+5m. The values are percentages, and a negative bound is the ordinary way to ask
+for pools that fell.
+
+```js
+// Pools up at least 50% in the last hour, biggest mover first
+const gainers = await client.pools.filter('ethereum', {
+  priceChange1hMin: 50,
+  sortBy: 'price_change_percentage_1h',
+  limit: 10
+});
+
+// Pools down at least 20% on the day
+const losers = await client.pools.filter('ethereum', {
+  priceChange24hMax: -20,
+  limit: 10
+});
+```
+
+Every window has a `Min` and a `Max` form: `priceChange24hMin`/`Max`,
+`priceChange6hMin`/`Max`, `priceChange1hMin`/`Max`, `priceChange5mMin`/`Max`.
+
+Pool sort fields: `volume_usd_24h`, `volume_usd_7d`, `volume_usd_30d`,
+`liquidity_usd`, `txns_24h`, `created_at`, `price_usd`,
+`price_change_percentage_24h`, `price_change_percentage_6h`,
+`price_change_percentage_1h`, `price_change_percentage_5m`.
+
+The 6h, 1h and 5m windows are pools-only. The token search endpoint rejects them
+with HTTP 400 and token rows carry no such field, so `tokens.getTop()` and
+`tokens.filter()` do not take them.
+
 ### Top Tokens & Token Filtering
 
 Both are backed by `/networks/{network}/tokens/search` and return

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-sdk",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4"
@@ -15,81 +15,454 @@
         "@types/node": "^26.0.1",
         "date-fns": "^4.1.0",
         "rimraf": "^6.0.1",
-        "ts-node": "^10.9.2",
+        "tsx": "^4.23.10",
         "typescript": "^7.0.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
+      "optional": true,
+      "os": [
+        "aix"
+      ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@types/node": {
       "version": "26.1.2",
@@ -441,32 +814,6 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -478,13 +825,6 @@
       "engines": {
         "node": ">= 6.0.0"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -552,13 +892,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/date-fns": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -594,16 +927,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -665,6 +988,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -699,6 +1064,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -839,13 +1219,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -961,48 +1334,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+    "node_modules/tsx": {
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.10.tgz",
+      "integrity": "sha512-0Vb9eKU47njkxv/6B8CRZRDsxNDT/Pz+BIU+M5jw7xL3TdzAjSxlZUxu0xFL/kLpaG3sHZ0LH2wbK1T1yo7CUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
+        "esbuild": "~0.28.0"
       },
       "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
+        "tsx": "dist/cli.mjs"
       },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
+      "engines": {
+        "node": ">=18.0.0"
       },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {
@@ -1046,23 +1394,6 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "ts-node tests/test-basic.ts",
-    "test:migration": "ts-node tests/test-migration.ts",
-    "test:endpoints": "ts-node tests/test-new-endpoints.ts",
-    "test:all": "npm test && npm run verify && npm run verify:real && ts-node tests/test-token-summary.ts && npm run test:migration && npm run test:endpoints",
-    "example": "ts-node examples/basic-example.ts",
-    "example:cache": "ts-node examples/retry-cache-example.ts",
-    "verify": "ts-node tests/test-retry-cache.ts",
-    "verify:real": "ts-node tests/test-real-world.ts"
+    "test": "tsx tests/test-basic.ts",
+    "test:migration": "tsx tests/test-migration.ts",
+    "test:params": "tsx tests/test-search-params.ts",
+    "test:endpoints": "tsx tests/test-new-endpoints.ts",
+    "test:all": "npm test && npm run verify && npm run verify:real && tsx tests/test-token-summary.ts && npm run test:migration && npm run test:params && npm run test:endpoints",
+    "example": "tsx examples/basic-example.ts",
+    "example:cache": "tsx examples/retry-cache-example.ts",
+    "verify": "tsx tests/test-retry-cache.ts",
+    "verify:real": "tsx tests/test-real-world.ts"
   },
   "keywords": [
     "dexpaprika",
@@ -39,7 +40,7 @@
     "@types/node": "^26.0.1",
     "date-fns": "^4.1.0",
     "rimraf": "^6.0.1",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.23.10",
     "typescript": "^7.0.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "JavaScript SDK for the DexPaprika API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,7 +10,8 @@
     "prepublishOnly": "npm run clean && npm run build",
     "test": "ts-node tests/test-basic.ts",
     "test:migration": "ts-node tests/test-migration.ts",
-    "test:all": "npm test && npm run verify && npm run verify:real && ts-node tests/test-token-summary.ts && npm run test:migration",
+    "test:endpoints": "ts-node tests/test-new-endpoints.ts",
+    "test:all": "npm test && npm run verify && npm run verify:real && ts-node tests/test-token-summary.ts && npm run test:migration && npm run test:endpoints",
     "example": "ts-node examples/basic-example.ts",
     "example:cache": "ts-node examples/retry-cache-example.ts",
     "verify": "ts-node tests/test-retry-cache.ts",

--- a/src/api/pools.ts
+++ b/src/api/pools.ts
@@ -213,12 +213,17 @@ export class PoolsAPI extends BaseAPI {
   }
 
   /**
-   * Filter pools on a network by volume, liquidity, transactions, and creation date.
+   * Filter pools on a network by volume, liquidity, transactions, price change,
+   * and creation date.
    *
    * Backed by the unified /networks/{network}/pools/search endpoint. The request
    * sends `order_by` (mapped from the legacy `sortBy`) and `sort` (direction),
    * and is cursor-paginated (pass `cursor`; read `has_next_page`/`next_cursor`
    * from the response). Legacy filter param names are mapped to canonical ones.
+   *
+   * The endpoint ignores query parameters it does not recognize and still
+   * answers 200, so a misspelled bound comes back as a full unfiltered page
+   * rather than an error. Compare against an unfiltered call when in doubt.
    *
    * @param networkId - Network identifier (e.g., 'ethereum', 'solana')
    * @param options - Filter criteria and cursor pagination options
@@ -247,6 +252,14 @@ export class PoolsAPI extends BaseAPI {
     if (options?.liquidityUsdMin !== undefined) filters.liquidity_usd_min = options.liquidityUsdMin;
     if (options?.liquidityUsdMax !== undefined) filters.liquidity_usd_max = options.liquidityUsdMax;
     if (options?.txns24hMin !== undefined) filters.txns_24h_min = options.txns24hMin;
+    if (options?.priceChange24hMin !== undefined) filters.price_change_percentage_24h_min = options.priceChange24hMin;
+    if (options?.priceChange24hMax !== undefined) filters.price_change_percentage_24h_max = options.priceChange24hMax;
+    if (options?.priceChange6hMin !== undefined) filters.price_change_percentage_6h_min = options.priceChange6hMin;
+    if (options?.priceChange6hMax !== undefined) filters.price_change_percentage_6h_max = options.priceChange6hMax;
+    if (options?.priceChange1hMin !== undefined) filters.price_change_percentage_1h_min = options.priceChange1hMin;
+    if (options?.priceChange1hMax !== undefined) filters.price_change_percentage_1h_max = options.priceChange1hMax;
+    if (options?.priceChange5mMin !== undefined) filters.price_change_percentage_5m_min = options.priceChange5mMin;
+    if (options?.priceChange5mMax !== undefined) filters.price_change_percentage_5m_max = options.priceChange5mMax;
     if (options?.createdAfter !== undefined) filters.created_after = options.createdAfter;
     if (options?.createdBefore !== undefined) filters.created_before = options.createdBefore;
     Object.assign(params, mapPoolFilterParams(filters));

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -94,12 +94,19 @@ export class TokensAPI extends BaseAPI {
   }
 
   /**
-   * Filter tokens on a network by volume, liquidity, FDV, transactions, and creation date.
+   * Filter tokens on a network by volume, liquidity, FDV, transactions, 24h
+   * price change, and creation date.
    *
    * Backed by the unified /networks/{network}/tokens/search endpoint. The request
    * sends `order_by` (mapped from the legacy `sortBy`) and `sort` (direction),
    * and is cursor-paginated (pass `cursor`; read `has_next_page`/`next_cursor`
    * from the response). Legacy filter param names are mapped to canonical ones.
+   *
+   * The endpoint answers 200 for query parameters it does not recognize and
+   * ignores them, so a bound it does not support looks exactly like a wide
+   * filter. Only the 24h price-change window is bounded here; the 6h, 1h and
+   * 5m bounds are accepted and ignored by this endpoint, so the SDK does not
+   * offer them. They work on `pools.filter()`.
    *
    * @param networkId - Network ID (e.g., "ethereum", "solana")
    * @param options - Filter criteria and cursor pagination options
@@ -123,6 +130,8 @@ export class TokensAPI extends BaseAPI {
     if (options?.fdvMin !== undefined) filters.fdv_min = options.fdvMin;
     if (options?.fdvMax !== undefined) filters.fdv_max = options.fdvMax;
     if (options?.txns24hMin !== undefined) filters.txns_24h_min = options.txns24hMin;
+    if (options?.priceChange24hMin !== undefined) filters.price_change_percentage_24h_min = options.priceChange24hMin;
+    if (options?.priceChange24hMax !== undefined) filters.price_change_percentage_24h_max = options.priceChange24hMax;
     if (options?.createdAfter !== undefined) filters.created_after = options.createdAfter;
     if (options?.createdBefore !== undefined) filters.created_before = options.createdBefore;
     Object.assign(params, mapTokenFilterParams(filters));

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -111,6 +111,26 @@ export interface PoolFilterOptions {
   liquidityUsdMax?: number;
   /** Minimum 24h transaction count */
   txns24hMin?: number;
+  // Price-change bounds, in percent, on the four windows pools/search supports.
+  // Negative values are meaningful and common: priceChange24hMax: -20 finds
+  // pools down at least a fifth on the day. These windows are pools only; the
+  // token search endpoint does not accept them.
+  /** Minimum 24h price change, in percent */
+  priceChange24hMin?: number;
+  /** Maximum 24h price change, in percent */
+  priceChange24hMax?: number;
+  /** Minimum 6h price change, in percent */
+  priceChange6hMin?: number;
+  /** Maximum 6h price change, in percent */
+  priceChange6hMax?: number;
+  /** Minimum 1h price change, in percent */
+  priceChange1hMin?: number;
+  /** Maximum 1h price change, in percent */
+  priceChange1hMax?: number;
+  /** Minimum 5m price change, in percent */
+  priceChange5mMin?: number;
+  /** Maximum 5m price change, in percent */
+  priceChange5mMax?: number;
   /** Only pools created after this Unix timestamp */
   createdAfter?: number | string;
   /** Only pools created before this Unix timestamp */

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -113,8 +113,9 @@ export interface PoolFilterOptions {
   txns24hMin?: number;
   // Price-change bounds, in percent, on the four windows pools/search supports.
   // Negative values are meaningful and common: priceChange24hMax: -20 finds
-  // pools down at least a fifth on the day. These windows are pools only; the
-  // token search endpoint does not accept them.
+  // pools down at least a fifth on the day. The 24h window also works on
+  // tokens/search (see TokenFilterOptions); the 6h, 1h and 5m windows are
+  // pools only, and tokens/search ignores them without an error.
   /** Minimum 24h price change, in percent */
   priceChange24hMin?: number;
   /** Maximum 24h price change, in percent */
@@ -179,6 +180,14 @@ export interface TokenFilterOptions {
   fdvMax?: number;
   /** Minimum 24h transaction count */
   txns24hMin?: number;
+  // Only the 24h price-change window is bounded here. tokens/search accepts
+  // price_change_percentage_24h_min and _max and applies them; it ignores the
+  // 6h, 1h and 5m bounds silently, so offering those options would return a
+  // full unfiltered page that looks like a successful filter.
+  /** Minimum 24h price change, in percent */
+  priceChange24hMin?: number;
+  /** Maximum 24h price change, in percent */
+  priceChange24hMax?: number;
   /** Only tokens created after this Unix timestamp */
   createdAfter?: number | string;
   /** Only tokens created before this Unix timestamp */

--- a/src/models/pools.ts
+++ b/src/models/pools.ts
@@ -69,6 +69,7 @@ export interface SearchPool {
   price_usd?: number;
   price_change_percentage_5m?: number | null;
   price_change_percentage_1h?: number | null;
+  price_change_percentage_6h?: number | null;
   price_change_percentage_24h?: number | null;
   tokens: PoolTokenRef[];
 }

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -28,8 +28,9 @@ const POOL_SORT_FIELD_MAP: Record<string, string> = {
   created_at: 'created_at',
   price_usd: 'price_usd',
   price_change_percentage_24h: 'price_change_percentage_24h',
-  // Shorter price-change windows, pools only. tokens/search rejects them with
-  // a 400 and TOKEN_SORT_FIELD_MAP deliberately does not list them.
+  // The three short price-change windows. Sorting by them is a pools/search
+  // feature: tokens/search answers 400, so TOKEN_SORT_FIELD_MAP deliberately
+  // does not list them. The 24h window above is common to both endpoints.
   price_change_percentage_6h: 'price_change_percentage_6h',
   price_change_percentage_1h: 'price_change_percentage_1h',
   price_change_percentage_5m: 'price_change_percentage_5m',
@@ -37,9 +38,10 @@ const POOL_SORT_FIELD_MAP: Record<string, string> = {
 
 // Tokens: legacy aliases plus canonical pass-through. Unknown -> default.
 // Note: tokens/search returns 400 on price ordering, so price_usd folds to the
-// default volume_usd_24h. The 6h/1h/5m price-change windows belong to
-// pools/search only: tokens/search returns 400 on them and token rows carry no
-// such field, so they stay out of this map on purpose.
+// default volume_usd_24h even though the endpoint's own 400 message lists it.
+// price_change_percentage_24h is supported and passes through. The 6h, 1h and
+// 5m windows are not: tokens/search returns 400 for them as an order_by value
+// and token rows carry no such field, so they stay out of this map on purpose.
 const TOKEN_SORT_FIELD_MAP: Record<string, string> = {
   // legacy -> canonical
   volume_24h: 'volume_usd_24h',

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -28,11 +28,18 @@ const POOL_SORT_FIELD_MAP: Record<string, string> = {
   created_at: 'created_at',
   price_usd: 'price_usd',
   price_change_percentage_24h: 'price_change_percentage_24h',
+  // Shorter price-change windows, pools only. tokens/search rejects them with
+  // a 400 and TOKEN_SORT_FIELD_MAP deliberately does not list them.
+  price_change_percentage_6h: 'price_change_percentage_6h',
+  price_change_percentage_1h: 'price_change_percentage_1h',
+  price_change_percentage_5m: 'price_change_percentage_5m',
 };
 
 // Tokens: legacy aliases plus canonical pass-through. Unknown -> default.
 // Note: tokens/search returns 400 on price ordering, so price_usd folds to the
-// default volume_usd_24h.
+// default volume_usd_24h. The 6h/1h/5m price-change windows belong to
+// pools/search only: tokens/search returns 400 on them and token rows carry no
+// such field, so they stay out of this map on purpose.
 const TOKEN_SORT_FIELD_MAP: Record<string, string> = {
   // legacy -> canonical
   volume_24h: 'volume_usd_24h',
@@ -103,7 +110,8 @@ function remapKeys(
 
 /**
  * Rename legacy pool filter param names to the canonical pools/search names.
- * Names not in the map (e.g. liquidity_usd_min, txns_24h_min) pass through.
+ * Names not in the map (e.g. liquidity_usd_min, txns_24h_min,
+ * price_change_percentage_1h_min) pass through.
  */
 export function mapPoolFilterParams(params: Record<string, any>): Record<string, any> {
   return remapKeys(params, POOL_FILTER_PARAM_MAP);

--- a/tests/test-new-endpoints.ts
+++ b/tests/test-new-endpoints.ts
@@ -1,10 +1,11 @@
 /// <reference types="node" />
 import { DexPaprikaClient } from '../src';
 import { mapPoolSortField, mapTokenSortField } from '../src/utils/searchParams';
+import { sleep } from '../src/utils/helpers';
 
 // Test all 4 new endpoints against the live API
 async function main() {
-  console.log("Testing new DexPaprika SDK endpoints (v1.6.0)\n");
+  console.log("Testing DexPaprika SDK search endpoints against the live API\n");
   const client = new DexPaprikaClient();
   let passed = 0;
   let failed = 0;
@@ -51,37 +52,66 @@ async function main() {
   // answers 200, so a dropped or misspelled bound looks exactly like a wide
   // filter. Every check below compares against an unfiltered baseline or an
   // independently sorted page instead of trusting the status code.
-  await test('pools.filter - 1h price change bound applies', async () => {
+  //
+  // The names the SDK puts on the wire are pinned offline in
+  // tests/test-search-params.ts, which needs no network and no market. What
+  // follows proves the live API still honours each bound.
+  await test('pools.filter - all eight price-change bounds apply', async () => {
     const baseline = await client.pools.filter('ethereum', { limit: 5 });
-    const baselineChanges = baseline.results.map(p => p.price_change_percentage_1h ?? 0);
-    if (baselineChanges.length === 0) throw new Error('No baseline results');
-    if (baselineChanges.every(c => c >= 50)) {
-      throw new Error(`Baseline already clears the bound, so it proves nothing: ${baselineChanges}`);
+    if (baseline.results.length === 0) throw new Error('No baseline results');
+
+    type Window = '24h' | '6h' | '1h' | '5m';
+    const read = (pool: any, w: Window): number | null | undefined =>
+      pool[`price_change_percentage_${w}`];
+
+    // 10 percent is far enough outside the ordinary spread that the unfiltered
+    // page never clears it, on any of the four windows, and close enough in
+    // that ethereum usually has rows on the daily and hourly ones.
+    const BOUND = 10;
+    const checks: { option: string; window: Window; kind: 'min' | 'max' }[] = [];
+    for (const w of ['24h', '6h', '1h', '5m'] as Window[]) {
+      checks.push({ option: `priceChange${w}Min`, window: w, kind: 'min' });
+      checks.push({ option: `priceChange${w}Max`, window: w, kind: 'max' });
     }
 
-    const gainers = await client.pools.filter('ethereum', { priceChange1hMin: 50, limit: 5 });
-    if (gainers.results.length === 0) throw new Error('No pools up 50% in an hour');
-    for (const pool of gainers.results) {
-      const change = pool.price_change_percentage_1h;
-      if (change === undefined || change === null || change < 50) {
-        throw new Error(`Pool ${pool.id} reports a 1h change of ${change}, the bound was 50`);
-      }
-    }
-    const shown = (xs: (number | null | undefined)[]) => xs.map(x => (x ?? 0).toFixed(3)).join(', ');
-    console.log(`   Baseline ${shown(baselineChanges)} vs filtered ${shown(gainers.results.map(p => p.price_change_percentage_1h))}`);
-  });
+    const notes: string[] = [];
+    for (const { option, window, kind } of checks) {
+      const bound = kind === 'min' ? BOUND : -BOUND;
 
-  await test('pools.filter - negative 24h bound applies', async () => {
-    // A max on a price change is usually negative. -20 means down at least a fifth.
-    const losers = await client.pools.filter('ethereum', { priceChange24hMax: -20, limit: 5 });
-    if (losers.results.length === 0) throw new Error('No pools down 20% on the day');
-    for (const pool of losers.results) {
-      const change = pool.price_change_percentage_24h;
-      if (change === undefined || change === null || change > -20) {
-        throw new Error(`Pool ${pool.id} reports a 24h change of ${change}, the bound was -20`);
+      // The baseline has to fail the bound, otherwise a filter that did nothing
+      // would pass this check by accident.
+      const baselineClears = baseline.results.every(p => {
+        const v = read(p, window);
+        if (v === undefined || v === null) return false;
+        return kind === 'min' ? v >= bound : v <= bound;
+      });
+      if (baselineClears) {
+        throw new Error(`Unfiltered page already satisfies ${option}: ${bound}, so the check proves nothing`);
       }
+
+      const page = await client.pools.filter('ethereum', { [option]: bound, limit: 5 } as any);
+
+      if (page.results.length === 0) {
+        // An ignored bound returns the full unfiltered page, never an empty
+        // one, so zero rows still tells the two apart. It happens on the 5m
+        // window in a quiet market and is not a failure.
+        notes.push(`${option} empty`);
+        continue;
+      }
+
+      for (const pool of page.results) {
+        const v = read(pool, window);
+        if (v === undefined || v === null) {
+          throw new Error(`Pool ${pool.id} came back under ${option}: ${bound} with no ${window} value`);
+        }
+        if (kind === 'min' ? v < bound : v > bound) {
+          throw new Error(`Pool ${pool.id} reports a ${window} change of ${v}, the bound was ${option}: ${bound}`);
+        }
+      }
+      notes.push(`${option} ${page.results.length} rows`);
+      await sleep(400);
     }
-    console.log(`   ${losers.results.length} pools down at least 20% on the day`);
+    console.log(`   ${notes.join(', ')}`);
   });
 
   await test('pools.filter - sorting by a short price-change window', async () => {
@@ -89,22 +119,32 @@ async function main() {
     const byChange = await client.pools.filter('ethereum', { sortBy: 'price_change_percentage_1h', limit: 5 });
     if (byChange.results.length === 0) throw new Error('No results');
     // An unknown sort field folds to volume_usd_24h before the request goes
-    // out, which would hand back the volume-sorted page with a 200.
-    if (byChange.results[0].id === byVolume.results[0].id) {
+    // out, which would hand back the volume-sorted page with a 200. Comparing
+    // whole pages rather than the top row alone makes a chance match unlikely.
+    if (byChange.results.map(p => p.id).join(',') === byVolume.results.map(p => p.id).join(',')) {
       throw new Error('Sorting by 1h price change returned the volume-sorted page');
     }
-    let previous = Infinity;
-    for (const pool of byChange.results) {
-      const change = pool.price_change_percentage_1h ?? -Infinity;
-      if (change > previous) {
-        throw new Error(`Page is not ordered by 1h change: ${change} came after ${previous}`);
-      }
-      previous = change;
+    // Null 1h values are skipped rather than coerced. Coercing them to
+    // -Infinity would let a page of nulls pass the ordering check having
+    // compared nothing at all.
+    const ordered = byChange.results
+      .map(p => p.price_change_percentage_1h)
+      .filter((c): c is number => typeof c === 'number');
+    if (ordered.length < 2) {
+      throw new Error(`Only ${ordered.length} rows carry a 1h value, cannot check ordering`);
     }
-    console.log(`   Top 1h mover: ${byChange.results[0].price_change_percentage_1h?.toFixed(2)}%`);
+    for (let i = 1; i < ordered.length; i++) {
+      if (ordered[i] > ordered[i - 1]) {
+        throw new Error(`Page is not ordered by 1h change: ${ordered[i]} came after ${ordered[i - 1]}`);
+      }
+    }
+    console.log(`   Top 1h mover: ${ordered[0].toFixed(2)}%, ${ordered.length} rows checked for order`);
   });
 
-  await test('price-change windows are pools only', async () => {
+  await test('short price-change windows are pools only', async () => {
+    // The 24h window works on both endpoints, for sorting and for filtering.
+    // Only 6h, 1h and 5m are pools-only, and they fail differently: tokens/search
+    // returns 400 for them as a sort field, and ignores them as a filter bound.
     const windows = [
       'price_change_percentage_6h',
       'price_change_percentage_1h',
@@ -120,6 +160,9 @@ async function main() {
         throw new Error(`mapTokenSortField('${field}') gave '${mapTokenSortField(field)}', expected the volume_usd_24h fallback`);
       }
     }
+    if (mapTokenSortField('price_change_percentage_24h') !== 'price_change_percentage_24h') {
+      throw new Error('The 24h window must keep passing through on tokens/search');
+    }
     const tokens = await client.tokens.getTop('ethereum', { limit: 1 });
     if (tokens.results.length === 0) throw new Error('No tokens');
     const row = tokens.results[0] as unknown as Record<string, unknown>;
@@ -128,7 +171,43 @@ async function main() {
         throw new Error(`Token rows now carry ${field}; recheck whether tokens/search accepts the window`);
       }
     }
-    console.log('   Pool sort fields pass through, token sort fields fall back, token rows carry no short window');
+    if (row.price_change_percentage_24h === undefined) {
+      throw new Error('Token rows no longer carry price_change_percentage_24h');
+    }
+    console.log('   6h/1h/5m pass through on pools and fall back on tokens, 24h works on both');
+  });
+
+  await test('tokens.filter - 24h price change bounds apply', async () => {
+    const baseline = await client.tokens.getTop('ethereum', { limit: 5 });
+    if (baseline.results.length === 0) throw new Error('No baseline tokens');
+    const baselineChanges = baseline.results.map(t => t.price_change_percentage_24h);
+    if (baselineChanges.every(c => typeof c === 'number' && c >= 20)) {
+      throw new Error(`Unfiltered page already clears the bound: ${baselineChanges}`);
+    }
+
+    const gainers = await client.tokens.filter('ethereum', { priceChange24hMin: 20, limit: 5 });
+    for (const token of gainers.results) {
+      const change = token.price_change_percentage_24h;
+      if (typeof change !== 'number' || change < 20) {
+        throw new Error(`Token ${token.address} reports a 24h change of ${change}, the bound was 20`);
+      }
+    }
+
+    await sleep(400);
+    const losers = await client.tokens.filter('ethereum', { priceChange24hMax: -20, limit: 5 });
+    for (const token of losers.results) {
+      const change = token.price_change_percentage_24h;
+      if (typeof change !== 'number' || change > -20) {
+        throw new Error(`Token ${token.address} reports a 24h change of ${change}, the bound was -20`);
+      }
+    }
+    // An ignored bound hands back the unfiltered page, so an empty page is
+    // still a filter that ran. Both pages empty at once would mean ethereum
+    // has nothing moving 20% either way, which is worth looking at by hand.
+    if (gainers.results.length === 0 && losers.results.length === 0) {
+      throw new Error('Both 24h bounds returned nothing, so neither direction was exercised');
+    }
+    console.log(`   ${gainers.results.length} tokens up 20%+, ${losers.results.length} down 20%+`);
   });
 
   // 2. Top Tokens

--- a/tests/test-new-endpoints.ts
+++ b/tests/test-new-endpoints.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 import { DexPaprikaClient } from '../src';
+import { mapPoolSortField, mapTokenSortField } from '../src/utils/searchParams';
 
 // Test all 4 new endpoints against the live API
 async function main() {
@@ -43,6 +44,91 @@ async function main() {
     });
     if (!result.results) throw new Error('No results');
     console.log(`   Got ${result.results.length} pools with multi-filter`);
+  });
+
+  // 1b. Price-change windows on pools/search.
+  // /pools/search ignores query parameters it does not recognize and still
+  // answers 200, so a dropped or misspelled bound looks exactly like a wide
+  // filter. Every check below compares against an unfiltered baseline or an
+  // independently sorted page instead of trusting the status code.
+  await test('pools.filter - 1h price change bound applies', async () => {
+    const baseline = await client.pools.filter('ethereum', { limit: 5 });
+    const baselineChanges = baseline.results.map(p => p.price_change_percentage_1h ?? 0);
+    if (baselineChanges.length === 0) throw new Error('No baseline results');
+    if (baselineChanges.every(c => c >= 50)) {
+      throw new Error(`Baseline already clears the bound, so it proves nothing: ${baselineChanges}`);
+    }
+
+    const gainers = await client.pools.filter('ethereum', { priceChange1hMin: 50, limit: 5 });
+    if (gainers.results.length === 0) throw new Error('No pools up 50% in an hour');
+    for (const pool of gainers.results) {
+      const change = pool.price_change_percentage_1h;
+      if (change === undefined || change === null || change < 50) {
+        throw new Error(`Pool ${pool.id} reports a 1h change of ${change}, the bound was 50`);
+      }
+    }
+    const shown = (xs: (number | null | undefined)[]) => xs.map(x => (x ?? 0).toFixed(3)).join(', ');
+    console.log(`   Baseline ${shown(baselineChanges)} vs filtered ${shown(gainers.results.map(p => p.price_change_percentage_1h))}`);
+  });
+
+  await test('pools.filter - negative 24h bound applies', async () => {
+    // A max on a price change is usually negative. -20 means down at least a fifth.
+    const losers = await client.pools.filter('ethereum', { priceChange24hMax: -20, limit: 5 });
+    if (losers.results.length === 0) throw new Error('No pools down 20% on the day');
+    for (const pool of losers.results) {
+      const change = pool.price_change_percentage_24h;
+      if (change === undefined || change === null || change > -20) {
+        throw new Error(`Pool ${pool.id} reports a 24h change of ${change}, the bound was -20`);
+      }
+    }
+    console.log(`   ${losers.results.length} pools down at least 20% on the day`);
+  });
+
+  await test('pools.filter - sorting by a short price-change window', async () => {
+    const byVolume = await client.pools.filter('ethereum', { sortBy: 'volume_usd_24h', limit: 5 });
+    const byChange = await client.pools.filter('ethereum', { sortBy: 'price_change_percentage_1h', limit: 5 });
+    if (byChange.results.length === 0) throw new Error('No results');
+    // An unknown sort field folds to volume_usd_24h before the request goes
+    // out, which would hand back the volume-sorted page with a 200.
+    if (byChange.results[0].id === byVolume.results[0].id) {
+      throw new Error('Sorting by 1h price change returned the volume-sorted page');
+    }
+    let previous = Infinity;
+    for (const pool of byChange.results) {
+      const change = pool.price_change_percentage_1h ?? -Infinity;
+      if (change > previous) {
+        throw new Error(`Page is not ordered by 1h change: ${change} came after ${previous}`);
+      }
+      previous = change;
+    }
+    console.log(`   Top 1h mover: ${byChange.results[0].price_change_percentage_1h?.toFixed(2)}%`);
+  });
+
+  await test('price-change windows are pools only', async () => {
+    const windows = [
+      'price_change_percentage_6h',
+      'price_change_percentage_1h',
+      'price_change_percentage_5m',
+    ];
+    for (const field of windows) {
+      if (mapPoolSortField(field) !== field) {
+        throw new Error(`mapPoolSortField('${field}') gave '${mapPoolSortField(field)}', expected pass-through`);
+      }
+      // tokens/search answers 400 on these windows, so folding them to the
+      // default is the correct behaviour rather than a gap to be filled.
+      if (mapTokenSortField(field) !== 'volume_usd_24h') {
+        throw new Error(`mapTokenSortField('${field}') gave '${mapTokenSortField(field)}', expected the volume_usd_24h fallback`);
+      }
+    }
+    const tokens = await client.tokens.getTop('ethereum', { limit: 1 });
+    if (tokens.results.length === 0) throw new Error('No tokens');
+    const row = tokens.results[0] as unknown as Record<string, unknown>;
+    for (const field of windows) {
+      if (row[field] !== undefined) {
+        throw new Error(`Token rows now carry ${field}; recheck whether tokens/search accepts the window`);
+      }
+    }
+    console.log('   Pool sort fields pass through, token sort fields fall back, token rows carry no short window');
   });
 
   // 2. Top Tokens

--- a/tests/test-search-params.ts
+++ b/tests/test-search-params.ts
@@ -1,0 +1,207 @@
+/// <reference types="node" />
+// Offline checks on the query the SDK builds for the two search endpoints.
+//
+// Why this file exists: /pools/search and /tokens/search answer 200 for query
+// parameters they do not recognize, and silently ignore them. A bound that the
+// SDK spells wrong, or drops on the floor, therefore comes back as a full
+// unfiltered page rather than an error, and a live test that only checks the
+// status code cannot tell the two apart. These checks read the params off the
+// client before any request goes out, so a rename or a typo in src/api fails
+// here immediately, with no network and no market conditions involved.
+//
+// The live counterpart lives in tests/test-new-endpoints.ts and proves the API
+// still honours each bound today.
+
+import { DexPaprikaClient } from '../src';
+import { PoolsAPI } from '../src/api/pools';
+import { TokensAPI } from '../src/api/tokens';
+import { mapPoolSortField, mapTokenSortField } from '../src/utils/searchParams';
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      console.log(`PASS  ${name}`);
+      passed++;
+    })
+    .catch((err: any) => {
+      console.error(`FAIL  ${name}: ${err.message || err}`);
+      failed++;
+    });
+}
+
+// A client that records the endpoint and params of every GET and answers with
+// an empty search page instead of calling the API.
+class RecordingClient extends DexPaprikaClient {
+  public calls: { endpoint: string; params: Record<string, any> }[] = [];
+
+  async get<T>(endpoint: string, params?: Record<string, any>): Promise<T> {
+    this.calls.push({ endpoint, params: { ...(params ?? {}) } });
+    return { results: [], has_next_page: false, next_cursor: null } as unknown as T;
+  }
+
+  lastParams(): Record<string, any> {
+    const call = this.calls[this.calls.length - 1];
+    if (!call) throw new Error('No request was made');
+    return call.params;
+  }
+
+  lastEndpoint(): string {
+    const call = this.calls[this.calls.length - 1];
+    if (!call) throw new Error('No request was made');
+    return call.endpoint;
+  }
+}
+
+function assertEqual(actual: unknown, expected: unknown, what: string) {
+  if (actual !== expected) {
+    throw new Error(`${what}: got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`);
+  }
+}
+
+// Every price-change bound pools.filter() accepts, with the exact query
+// parameter name it has to reach /pools/search under. Getting a name wrong here
+// is invisible over the wire, so this table is the specification.
+const POOL_BOUNDS: [keyof import('../src/models/options').PoolFilterOptions, string][] = [
+  ['priceChange24hMin', 'price_change_percentage_24h_min'],
+  ['priceChange24hMax', 'price_change_percentage_24h_max'],
+  ['priceChange6hMin', 'price_change_percentage_6h_min'],
+  ['priceChange6hMax', 'price_change_percentage_6h_max'],
+  ['priceChange1hMin', 'price_change_percentage_1h_min'],
+  ['priceChange1hMax', 'price_change_percentage_1h_max'],
+  ['priceChange5mMin', 'price_change_percentage_5m_min'],
+  ['priceChange5mMax', 'price_change_percentage_5m_max'],
+];
+
+const TOKEN_BOUNDS: [keyof import('../src/models/options').TokenFilterOptions, string][] = [
+  ['priceChange24hMin', 'price_change_percentage_24h_min'],
+  ['priceChange24hMax', 'price_change_percentage_24h_max'],
+];
+
+async function main() {
+  console.log('Checking the query the SDK builds for pools/search and tokens/search\n');
+
+  for (const [option, param] of POOL_BOUNDS) {
+    await test(`pools.filter sends ${String(option)} as ${param}`, async () => {
+      const client = new RecordingClient();
+      const pools = new PoolsAPI(client);
+      // 17.5 rather than a round number so a value picked up from the wrong
+      // option would not coincide with anything else in the request.
+      await pools.filter('ethereum', { [option]: 17.5 } as any);
+      assertEqual(client.lastEndpoint(), '/networks/ethereum/pools/search', 'endpoint');
+      assertEqual(client.lastParams()[param], 17.5, `params.${param}`);
+    });
+  }
+
+  await test('pools.filter keeps negative bounds negative', async () => {
+    const client = new RecordingClient();
+    const pools = new PoolsAPI(client);
+    await pools.filter('ethereum', { priceChange24hMax: -20, priceChange5mMin: -3.5 });
+    assertEqual(client.lastParams().price_change_percentage_24h_max, -20, 'params.price_change_percentage_24h_max');
+    assertEqual(client.lastParams().price_change_percentage_5m_min, -3.5, 'params.price_change_percentage_5m_min');
+  });
+
+  await test('pools.filter sends a zero bound rather than dropping it', async () => {
+    // 0 is falsy, so an `if (options.x)` guard would silently discard it and
+    // hand back the unfiltered page. The guards use `!== undefined` for this.
+    const client = new RecordingClient();
+    const pools = new PoolsAPI(client);
+    await pools.filter('ethereum', { priceChange1hMin: 0 });
+    assertEqual(client.lastParams().price_change_percentage_1h_min, 0, 'params.price_change_percentage_1h_min');
+  });
+
+  await test('pools.filter sends no price-change param when none was asked for', async () => {
+    const client = new RecordingClient();
+    const pools = new PoolsAPI(client);
+    await pools.filter('ethereum', { volume24hMin: 100000 });
+    const params = client.lastParams();
+    const stray = Object.keys(params).filter(k => k.startsWith('price_change_'));
+    if (stray.length > 0) {
+      throw new Error(`Unrequested price-change params in the query: ${stray.join(', ')}`);
+    }
+    assertEqual(params.volume_usd_24h_min, 100000, 'params.volume_usd_24h_min');
+  });
+
+  await test('pools.filter sends all eight bounds together, none overwriting another', async () => {
+    const client = new RecordingClient();
+    const pools = new PoolsAPI(client);
+    const options: Record<string, number> = {};
+    POOL_BOUNDS.forEach(([option], i) => {
+      options[String(option)] = i + 1;
+    });
+    await pools.filter('ethereum', options as any);
+    const params = client.lastParams();
+    POOL_BOUNDS.forEach(([option, param], i) => {
+      assertEqual(params[param], i + 1, `params.${param} (from ${String(option)})`);
+    });
+  });
+
+  for (const [option, param] of TOKEN_BOUNDS) {
+    await test(`tokens.filter sends ${String(option)} as ${param}`, async () => {
+      const client = new RecordingClient();
+      const tokens = new TokensAPI(client);
+      await tokens.filter('ethereum', { [option]: 17.5 } as any);
+      assertEqual(client.lastEndpoint(), '/networks/ethereum/tokens/search', 'endpoint');
+      assertEqual(client.lastParams()[param], 17.5, `params.${param}`);
+    });
+  }
+
+  await test('tokens.filter takes no bound on the short windows', async () => {
+    // tokens/search ignores 6h/1h/5m bounds instead of rejecting them, so the
+    // SDK must not offer an option that would look like it worked. Passing one
+    // anyway has to leave the query alone.
+    const client = new RecordingClient();
+    const tokens = new TokensAPI(client);
+    await tokens.filter('ethereum', { priceChange1hMin: 50, priceChange5mMax: -5 } as any);
+    const shortWindows = Object.keys(client.lastParams()).filter(
+      k => /price_change_percentage_(6h|1h|5m)_/.test(k)
+    );
+    if (shortWindows.length > 0) {
+      throw new Error(`tokens/search query carries short-window bounds it ignores: ${shortWindows.join(', ')}`);
+    }
+  });
+
+  await test('pool sort fields pass through for all four windows', async () => {
+    for (const field of [
+      'price_change_percentage_24h',
+      'price_change_percentage_6h',
+      'price_change_percentage_1h',
+      'price_change_percentage_5m',
+    ]) {
+      assertEqual(mapPoolSortField(field), field, `mapPoolSortField('${field}')`);
+    }
+    const client = new RecordingClient();
+    const pools = new PoolsAPI(client);
+    await pools.filter('ethereum', { sortBy: 'price_change_percentage_5m' });
+    assertEqual(client.lastParams().order_by, 'price_change_percentage_5m', 'params.order_by');
+  });
+
+  await test('token sort keeps 24h and folds the three short windows', async () => {
+    assertEqual(
+      mapTokenSortField('price_change_percentage_24h'),
+      'price_change_percentage_24h',
+      "mapTokenSortField('price_change_percentage_24h')"
+    );
+    for (const field of [
+      'price_change_percentage_6h',
+      'price_change_percentage_1h',
+      'price_change_percentage_5m',
+    ]) {
+      assertEqual(mapTokenSortField(field), 'volume_usd_24h', `mapTokenSortField('${field}')`);
+    }
+    // tokens/search also answers 400 on price_usd ordering, despite listing it
+    // in its own error enum, so that one folds to the default as well.
+    assertEqual(mapTokenSortField('price_usd'), 'volume_usd_24h', "mapTokenSortField('price_usd')");
+  });
+
+  console.log(`\n${'='.repeat(50)}`);
+  console.log(`RESULTS: ${passed} passed, ${failed} failed out of ${passed + failed} tests`);
+  console.log(`${'='.repeat(50)}`);
+
+  if (failed > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Rolls the new `/networks/{network}/pools/search` price-change capability into the TypeScript SDK. This is the TS surface of the same change already shipped to the hosted MCP worker, the npm MCP (dexpaprika-mcp#40) and the Go SDK (dexpaprika-sdk-go#22), and I kept the naming and the comment wording aligned with those.

Second commit on this branch fixes three things a review found. They are called out in place below, and the short version is in [Review round 2](#review-round-2) at the end.

## What the API accepts

Read off each endpoint's own 400 body rather than a docs page, re-run 2026-08-07:

```
curl "https://api.dexpaprika.com/networks/ethereum/pools/search?order_by=nope"
{"message":"invalid query parameters: order_by (must be one of
 [volume_usd_24h volume_usd_7d volume_usd_30d liquidity_usd txns_24h created_at
  price_usd price_change_percentage_24h price_change_percentage_6h
  price_change_percentage_1h price_change_percentage_5m])"}

curl "https://api.dexpaprika.com/networks/ethereum/tokens/search?order_by=nope"
{"message":"invalid query parameters: order_by (must be one of
 [volume_usd_24h volume_usd_7d volume_usd_30d price_usd liquidity_usd txns_24h
  price_change_percentage_24h created_at fdv_usd])"}
```

The three short windows are new, and they are on pools only. Filters go alongside them as `price_change_percentage_{24h,6h,1h,5m}_{min,max}`.

## Why this is worth care

Both ways of getting it wrong are silent, and both return HTTP 200 with a believable page of pools.

A sort field missing from `POOL_SORT_FIELD_MAP` never reaches the API to be rejected. `mapPoolSortField` folds anything unknown to `volume_usd_24h` before the request goes out, so a caller asking for the top 1h movers gets the highest-volume pools back and cannot tell the difference.

A filter parameter the API does not recognise is ignored, and it answers 200 with a full unfiltered result set. A green status code says nothing about whether the bound applied. The only real check compares against an unfiltered baseline.

## Changes

- `POOL_SORT_FIELD_MAP` gains canonical pass-through for `price_change_percentage_6h`, `_1h` and `_5m`.
- `PoolFilterOptions` gains eight bounds: `priceChange{24h,6h,1h,5m}{Min,Max}`. The 24h pair was missing as well, so it is included.
- `TokenFilterOptions` gains `priceChange24hMin` and `priceChange24hMax`. The 24h window is the one price-change bound `tokens/search` applies, and leaving it out was the tail of a mistake I had made in the prose. See [the token side](#the-token-side).
- `pools.filter()` and `tokens.filter()` map those options to the canonical query parameters. `POOL_FILTER_PARAM_MAP` and `TOKEN_FILTER_PARAM_MAP` are rename maps with pass-through, so the canonical names need no entry there.
- `SearchPool` gains `price_change_percentage_6h`, which pool rows already return.
- Every npm script moves from `ts-node` to `tsx`, which is why the tests in this PR can actually run. See [Test status](#test-status).
- `tests/test-search-params.ts` is new: offline checks on the query the SDK builds, no network involved.
- README documents the four windows, the full pool sort field list, what the token endpoint does with the same windows, and the two test files. CHANGELOG entry under 1.8.0 with a matching version bump. Drop the bump if it does not suit your release flow.

Negative values are the ordinary case rather than an edge case. `priceChange24hMax: -20` is how you ask for pools that fell at least a fifth.

## The token side

My first version of this PR said all four windows were pools-only. That is wrong, and it inverts the asymmetry the PR exists to protect. Only the three short windows are pools-only, and they fail two different ways on `tokens/search`:

| | as `order_by` | as a filter bound |
|---|---|---|
| `price_change_percentage_24h` | works | works |
| `_6h`, `_1h`, `_5m` | HTTP 400 | 200, silently ignored |

The proof on ethereum, run 2026-08-07, reading `price_change_percentage_24h` off six rows:

```
baseline                                  [95.7, -0.07, 0.24, -0.01, 0.48, 0.03]
price_change_percentage_24h_min=20        [95.7, 36.6, 16672.6, 23.0, 33.2, 1251.1]
price_change_pct_24h_min=20   misspelled  [95.7, -0.07, 0.24, -0.01, 0.48, 0.03]
price_change_percentage_6h_min=20         [95.7, -0.07, 0.23, -0.02, 0.40, 0.04]
price_change_percentage_24h_max=-20       [-99.4, -22.5, -56.1, -86.6, -27.5, -46.2]
```

The misspelled row coming back identical to the baseline is what proves the correctly spelled one did something. The 6h row coming back identical to the baseline is what proves the short windows really are ignored here, which a status code alone would never have shown.

So `TOKEN_SORT_FIELD_MAP` still folds the three short windows to the default, `TokenFilterOptions` still offers no bound on them, and `tokens.filter()` now takes the 24h pair that does work. A test pins the asymmetry in both directions, so a later sweep tidying up "missing" entries cannot turn the token map into a source of 400s.

The existing `price_usd` token remap stays as is. `tokens/search` advertises `price_usd` in its own 400 body and still rejects ordering by it, which I re-confirmed today: `{"message":"invalid query parameters"}`.

Token rows carry no short window at all. Live keys today: `address, chain, created_at, fdv_usd, liquidity_usd, price_change_percentage_24h, price_usd, txns_24h, volume_usd_24h, volume_usd_30d, volume_usd_7d`.

## Verified live against api.dexpaprika.com

These are readings taken on 2026-08-07, not properties of the endpoint. Prices move, so the numbers in any given column will be different by the time you read this. What holds is the contrast between the columns: an ignored parameter returns the baseline page, so a filtered page that differs from the baseline is a filter that ran.

Every bound at 10 percent, against the same unfiltered ethereum page, with the parameter misspelled as `_minimum` as a control. "Baseline page" in the last column means the same pools in the same order with the same near-zero changes, give or take a tick in the last decimal on rows that traded between the two calls.

| parameter | baseline | filtered | `_minimum` control |
|---|---|---|---|
| `..._24h_min=10` | 0, 0.006, 0.65, 0.011 | 33.4, 40.3, 22.9, 134.5 | baseline page |
| `..._24h_max=-10` | 0, 0.006, 0.65, 0.011 | -12.9, -21.0, -16.9, -23.1 | baseline page |
| `..._6h_min=10` | 0, 0.005, 0.92, -0.003 | 12.3, 21.4, 36.2, 182.3 | baseline page |
| `..._6h_max=-10` | 0, 0.005, 0.92, -0.003 | -12.7, -14.0, -16.3, -39.6 | baseline page |
| `..._1h_min=10` | 0, 0.016, 0.38, 0.009 | 76.8, 14.6, 10.3, 22.2 | baseline page |
| `..._1h_max=-10` | 0, 0.016, 0.38, 0.009 | -20.3, -60.5, -33.5, -26.4 | baseline page |
| `..._5m_min=10` | 0, 0.002, -0.013, -0.0003 | empty | baseline page |
| `..._5m_max=-10` | 0, 0.002, -0.013, -0.0003 | empty | baseline page |

The 5m rows are the interesting ones. An ignored parameter hands back the full baseline page and never an empty one, so an empty page is still a filter that ran. Nothing on ethereum moved 10 percent in five minutes at that moment, which is the normal state of that window. The live test treats an empty page that way rather than failing on it.

Sorting by each window returns a descending page that differs from the volume-sorted one.

## Failing controls

A check that cannot fail has verified nothing, so I broke each new test on purpose and watched it go red.

**All six previously uncovered bounds at once.** A reviewer misspelled the canonical name for six of the eight bounds in `src/api/pools.ts` and the old suite still reported `17 passed, 0 failed`, because only two bounds had any coverage. I reproduced that exact edit against the new offline suite:

```
npm run test:params
FAIL  pools.filter sends priceChange24hMin as price_change_percentage_24h_min: got undefined, expected 17.5
FAIL  pools.filter sends priceChange6hMin as price_change_percentage_6h_min: got undefined, expected 17.5
FAIL  pools.filter sends priceChange6hMax as price_change_percentage_6h_max: got undefined, expected 17.5
FAIL  pools.filter sends priceChange1hMax as price_change_percentage_1h_max: got undefined, expected 17.5
FAIL  pools.filter sends priceChange5mMin as price_change_percentage_5m_min: got undefined, expected 17.5
FAIL  pools.filter sends priceChange5mMax as price_change_percentage_5m_max: got undefined, expected 17.5
FAIL  pools.filter keeps negative bounds negative
FAIL  pools.filter sends all eight bounds together, none overwriting another
RESULTS: 9 passed, 8 failed out of 17 tests
exit code 1
```

Restored: `17 passed, 0 failed`, exit code 0.

**One bound on the live suite.** Renaming `price_change_percentage_6h_min` to `_6hr_min`:

```
npm run test:endpoints
pools.filter - all eight price-change bounds apply: Pool 0x14060f3b... reports a 6h change of 0, the bound was priceChange6hMin: 10
RESULTS: 16 passed, 1 failed out of 17 tests
exit code 1
```

The API had returned 200 with the unfiltered baseline page, which is the whole point.

**The new token bound.** Renaming `price_change_percentage_24h_min` to `price_change_pct_24h_min` in `src/api/tokens.ts` fails both suites:

```
npm run test:params
FAIL  tokens.filter sends priceChange24hMin as price_change_percentage_24h_min: got undefined, expected 17.5
RESULTS: 16 passed, 1 failed out of 17 tests

npm run test:endpoints
tokens.filter - 24h price change bounds apply: Token 0xa0b8699... reports a 24h change of -0.05, the bound was 20
RESULTS: 16 passed, 1 failed out of 17 tests
```

Both restored, both back to `17 passed, 0 failed`.

I also removed two ways the old tests could pass without checking anything. The descending-order assertion coerced null 1h values to `-Infinity`, so a page of nulls satisfied it having compared nothing at all; nulls are now skipped and the test requires at least two real values. The volume-page guard compared only the top row, so it now compares whole pages.

## Test status

Fixed in this PR, having previously said it was out of scope.

Every npm script in this repo invoked `ts-node`, and ts-node 10.9.2 dies on startup against the TypeScript 7 this SDK builds with:

```
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at readConfig (node_modules/ts-node/dist/configuration.js:91:33)
```

That break was already on main, and I first left it alone as its own piece of work. The problem with leaving it: `test:all` is an `&&` chain that dies at its first step, so the `test:endpoints` script I added to it could never run, and the CHANGELOG told users it did. A script that cannot execute is worse than no script. So every script now runs under `tsx`, `tsx` is a proper devDependency, and `ts-node` is gone.

Run end to end just now:

```
npm run build          exit 0
npm test               exit 0
npm run verify         exit 0
npm run verify:real    exit 0
npm run test:migration exit 0
npm run test:params    17 passed, 0 failed
npm run test:endpoints 17 passed, 0 failed
npm run test:all       exit 0
```

CI runs `npm run build` only, so this changes nothing there.

The README's `npx ts-node tests/test-real-world.ts` line was documenting a command that could not run either. It now says `npm run verify:real`, which I ran.

## Review round 2

Second commit, `387a414`:

1. **`test:endpoints` did not run.** Fixed by moving every script to `tsx`, above. The CHANGELOG bullet that claimed the script pinned the short-window behaviour is gone, replaced by a `### Fixed` entry about the runner, which is the user-facing part.
2. **Six of the eight bounds had no coverage.** Fixed by `tests/test-search-params.ts`, with the reviewer's own six-way misspelling reproduced as the failing control.
3. **"All four windows are pools-only" was false.** Fixed in the README, the CHANGELOG, three source comments and the live test, and `tokens.filter()` now takes the 24h bounds that do work.

Two nits I did not take. The live test file still prints check marks and crosses in its console output, which every test file in this repo does; changing one of them is churn that makes nothing more true. I also left the pre-existing `price_usd` token remap alone, since it predates this PR and I re-confirmed it is still correct.

https://claude.ai/code/session_016Zw5oLXk2fVxkVJvgqrc9j
