### PR TITLE
feat: optional API key, and a User-Agent that reports the real version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the DexPaprika SDK will be documented in this file.
 
+## [1.10.0] - 2026-08-14
+
+### Added
+- **Optional API key.** `new DexPaprikaClient(baseUrl, options, { apiKey })`, falling back to the `DEXPAPRIKA_API_KEY` environment variable when none is passed. Keyless remains the default and is unchanged: without a key the client sends exactly what it sent before. The key is transmitted as the **entire** `Authorization` value, with no `Bearer` prefix and no other scheme word, because the API checksums the raw header and a scheme word returns 401.
+- `resolveApiKey` is exported so callers can reuse the same precedence and validation.
+- The host is never inferred from the presence of a key. Free keys are served from the default `baseUrl` and only Pro moves to `api-pro.dexpaprika.com`, which callers pass as `baseUrl`. Sending a free key to the Pro host returns 403.
+
+### Fixed
+- **The User-Agent was pinned to `DexPaprika-SDK-JavaScript/0.1.0`** while the package shipped 1.9.0, so every request misreported which version sent it and no rollout could be measured. It is now derived from a `VERSION` constant in `src/version.ts`, with a test that fails if that constant drifts from `package.json`. `rootDir` is `./src`, so importing `package.json` directly would break the build; the test is the guard instead.
+
+### Notes
+- Reading the environment is guarded rather than assumed, so the package no longer touches `process` unconditionally and can be bundled for the browser.
+- New `npm run test:unit`, covering the bare-key format against five scheme words, keyless behaviour, precedence, whitespace trimming, rejection of keys carrying header-injection characters, and the host rules.
+
 ## 1.9.0 (2026-08-13)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -135,6 +135,50 @@ const ohlcv = await client.pools.getOHLCV(
 );
 ```
 
+## Using an API key (optional)
+
+**The SDK works without a key and always will.** No signup, no card. Everything
+below is optional.
+
+A free key raises the monthly credit allowance. It does **not** raise the
+per-minute request limit, which is the same on both free tiers. Current figures
+are on the [rate limits page](https://docs.dexpaprika.com/knowledge-base/rate-limits).
+
+```ts
+import { DexPaprikaClient } from 'dexpaprika-sdk';
+
+// Explicit
+const client = new DexPaprikaClient('https://api.dexpaprika.com', {}, {
+  apiKey: 'api_your_key_here',
+});
+
+// Or leave it out and set DEXPAPRIKA_API_KEY in the environment
+const client = new DexPaprikaClient();
+```
+
+An explicit `apiKey` beats the environment variable, and no key at all keeps the
+previous keyless behaviour unchanged. In a browser bundle, where there is no
+`process`, the environment is simply empty and the client stays keyless.
+
+**There is no `Bearer` prefix.** The key is sent as the entire `Authorization`
+value, which is what the API expects; a scheme word returns 401. You never write
+the header yourself, so this only matters when debugging what went out.
+
+**Pro customers** also pass the base URL, because the host does not change on its
+own. Free keys are served from the default host and sending one to the Pro host
+returns 403, so the switch has to be deliberate:
+
+```ts
+const client = new DexPaprikaClient('https://api-pro.dexpaprika.com', {}, {
+  apiKey: 'api_your_pro_key',
+});
+```
+
+**One gotcha worth knowing.** On the data endpoints a key the API cannot read is
+ignored rather than rejected: the call returns `200` with real data and you are
+quietly served as an anonymous caller. To confirm a key is landing, call `/usage`
+and check the `plan` field; `keyless` means the key never arrived.
+
 ## Advanced Configuration
 
 The SDK supports automatic retry with exponential backoff and response caching, both enabled by default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-sdk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-sdk",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "JavaScript SDK for the DexPaprika API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,7 +17,8 @@
     "example": "tsx examples/basic-example.ts",
     "example:cache": "tsx examples/retry-cache-example.ts",
     "verify": "tsx tests/test-retry-cache.ts",
-    "verify:real": "tsx tests/test-real-world.ts"
+    "verify:real": "tsx tests/test-real-world.ts",
+    "test:unit": "tsx tests/test-api-key.ts"
   },
   "keywords": [
     "dexpaprika",

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import { UtilsAPI } from './api/utils';
 import { DexesAPI } from './api/dexes';
 import { withRetry, RetryConfig, defaultRetryConfig } from './utils/helpers';
 import { Cache, CacheConfig } from './utils/cache';
+import { API_KEY_ENV_VAR, VERSION } from './version';
 
 /**
  * Client configuration options
@@ -16,6 +17,49 @@ export interface ClientConfig {
   retry?: Partial<RetryConfig>;
   /** Cache configuration */
   cache?: Partial<CacheConfig>;
+  /**
+   * Optional API key. Falls back to the DEXPAPRIKA_API_KEY environment variable.
+   *
+   * Keyless is the default and keeps working: without a key the client behaves
+   * exactly as before. The key is sent as the **entire** `Authorization` value,
+   * with no `Bearer` prefix and no other scheme word, because the API checksums
+   * the raw header and a scheme word returns 401.
+   *
+   * The host does not change when a key is present. Free keys are served from
+   * the default `baseUrl` and only Pro moves to `api-pro.dexpaprika.com`, which
+   * callers pass as `baseUrl`.
+   */
+  apiKey?: string;
+}
+
+/**
+ * Environment variables, or an empty object where there are none.
+ *
+ * This package can be bundled for the browser, where `process` does not exist,
+ * so reading it has to be guarded rather than assumed.
+ */
+function readEnvironment(): Record<string, string | undefined> {
+  const scope = globalThis as { process?: { env?: Record<string, string | undefined> } };
+  return scope.process?.env ?? {};
+}
+
+/**
+ * Read a usable key, or undefined for keyless.
+ *
+ * A key carrying CR, LF or NUL is dropped rather than sanitised: a mangled key
+ * authenticates as nobody, and because the data endpoints ignore an unreadable
+ * key instead of rejecting it, the caller would never find out.
+ */
+export function resolveApiKey(
+  explicit?: string,
+  env?: Record<string, string | undefined>,
+): string | undefined {
+  const source = env !== undefined ? env : readEnvironment();
+  const raw = explicit !== undefined ? explicit : source[API_KEY_ENV_VAR];
+  if (typeof raw !== 'string') return undefined;
+  const key = raw.trim();
+  if (key === '' || /[\r\n\0]/.test(key)) return undefined;
+  return key;
 }
 
 // Main client class
@@ -42,6 +86,7 @@ export class DexPaprikaClient {
     
     // Initialize configs with defaults
     this.retryConfig = { ...defaultRetryConfig, ...config.retry };
+    const apiKey = resolveApiKey(config.apiKey);
     this.cache = new Cache(config.cache);
     
     // Initialize HTTP client
@@ -49,7 +94,12 @@ export class DexPaprikaClient {
       ...options,
       headers: {
         'Content-Type': 'application/json',
-        'User-Agent': 'DexPaprika-SDK-JavaScript/0.1.0',
+        // Was pinned to 0.1.0 while the package shipped 1.9.0, so every request
+        // misreported which SDK sent it and no rollout could be measured.
+        'User-Agent': `DexPaprika-SDK-JavaScript/${VERSION}`,
+        // The whole value, with no scheme word in front of it. Spread last so a
+        // caller can still override anything here.
+        ...(apiKey ? { Authorization: apiKey } : {}),
         ...options.headers,
       },
     });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,12 @@
+/**
+ * SDK version, reported in the User-Agent.
+ *
+ * Kept here rather than imported from package.json because `rootDir` is `./src`,
+ * so reaching outside it breaks the build. `tests/test-api-key.ts` asserts this
+ * matches package.json, which is the guard that was missing: the User-Agent was
+ * pinned to 0.1.0 while the package shipped 1.9.0.
+ */
+export const VERSION = '1.10.0';
+
+/** Environment variable consulted when no key is passed to the constructor. */
+export const API_KEY_ENV_VAR = 'DEXPAPRIKA_API_KEY';

--- a/tests/test-api-key.ts
+++ b/tests/test-api-key.ts
@@ -1,0 +1,115 @@
+/**
+ * Optional API key, and the header rules that go with it.
+ *
+ * Assertions run against the axios instance the client actually built, so they
+ * describe what leaves the process rather than what was stored.
+ *
+ * Run: npm run test:unit
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DexPaprikaClient, resolveApiKey } from '../src/client';
+import { VERSION } from '../src/version';
+
+let failures = 0;
+function test(name: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`  FAIL ${name}\n       ${(error as Error).message}`);
+  }
+}
+
+/** Headers the client would send, read off the axios instance it built. */
+function headersFor(config: ConstructorParameters<typeof DexPaprikaClient>[2] = {}): Record<string, any> {
+  const client = new DexPaprikaClient('https://api.dexpaprika.com', {}, config);
+  return ((client as any).httpClient.defaults.headers ?? {}) as Record<string, any>;
+}
+
+// ── The Bearer rule ────────────────────────────────────────────────────────
+// Authorization: Bearer api_... returns 401 because the API checksums the raw
+// header value. The mistake has come back three times in four months.
+
+test('the key is the entire Authorization value', () => {
+  assert.equal(headersFor({ apiKey: 'api_abc123' }).Authorization, 'api_abc123');
+});
+
+test('no scheme word is ever prepended', () => {
+  const value = String(headersFor({ apiKey: 'api_abc123' }).Authorization);
+  for (const scheme of ['Bearer', 'Token', 'ApiKey', 'Basic', 'Key']) {
+    assert.ok(!value.toLowerCase().startsWith(scheme.toLowerCase()), `starts with ${scheme}`);
+  }
+});
+
+// ── Keyless stays the default ──────────────────────────────────────────────
+
+test('no key sends no Authorization header', () => {
+  assert.equal('Authorization' in headersFor(), false);
+});
+
+test('a blank key is keyless, not an empty header', () => {
+  for (const apiKey of ['', '   ', '\t']) {
+    assert.equal('Authorization' in headersFor({ apiKey }), false, `blank value ${JSON.stringify(apiKey)}`);
+  }
+});
+
+// ── Precedence and resolution ──────────────────────────────────────────────
+
+test('the environment variable is used when no key is passed', () => {
+  assert.equal(resolveApiKey(undefined, { DEXPAPRIKA_API_KEY: 'api_from_env' }), 'api_from_env');
+});
+
+test('an explicit key beats the environment', () => {
+  assert.equal(resolveApiKey('api_explicit', { DEXPAPRIKA_API_KEY: 'api_from_env' }), 'api_explicit');
+});
+
+test('surrounding whitespace is trimmed', () => {
+  assert.equal(resolveApiKey('  api_padded\n'), 'api_padded');
+});
+
+test('a key with control characters is dropped, not mangled', () => {
+  for (const value of ['api_a\r\nX-Evil: 1', 'api_a\nb', 'api_a\0b']) {
+    assert.equal(resolveApiKey(value), undefined, `expected ${JSON.stringify(value)} to be rejected`);
+  }
+});
+
+test('reading the environment does not throw where process is absent', () => {
+  assert.equal(resolveApiKey(undefined, {}), undefined);
+});
+
+// ── Identification ─────────────────────────────────────────────────────────
+
+test('the User-Agent carries the real package version', () => {
+  const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+  // The guard that was missing: the User-Agent said 0.1.0 while the package
+  // shipped 1.9.0, so every request misreported which SDK sent it.
+  assert.equal(VERSION, pkg.version, 'src/version.ts drifted from package.json');
+  assert.equal(headersFor()['User-Agent'], `DexPaprika-SDK-JavaScript/${pkg.version}`);
+});
+
+test('the User-Agent is not the literal that went stale', () => {
+  assert.notEqual(headersFor()['User-Agent'], 'DexPaprika-SDK-JavaScript/0.1.0');
+});
+
+// ── Host rules ─────────────────────────────────────────────────────────────
+
+test('a key alone never changes the host', () => {
+  // Free keys are served from the default host; only Pro moves, and a free key
+  // sent to the Pro host returns 403.
+  const client = new DexPaprikaClient(undefined as any, {}, { apiKey: 'api_abc123' });
+  assert.equal((client as any).baseUrl, 'https://api.dexpaprika.com');
+});
+
+test('Pro customers set the host explicitly', () => {
+  const client = new DexPaprikaClient('https://api-pro.dexpaprika.com', {}, { apiKey: 'api_pro' });
+  assert.equal((client as any).baseUrl, 'https://api-pro.dexpaprika.com');
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} failing`);
+  process.exit(1);
+}
+console.log('\nall api-key tests passed');


### PR DESCRIPTION
Part of #166 / [devrel#169](https://github.com/coinpaprika/devrel/issues/169).
Third of four. Same contract as
coinpaprika/dexpaprika-sdk-python#17 and coinpaprika/dexpaprika-sdk-go#26.

**Keyless stays the default and is untouched.**

### The key

```ts
new DexPaprikaClient('https://api.dexpaprika.com', {}, { apiKey: 'api_your_key' });
new DexPaprikaClient();   // or DEXPAPRIKA_API_KEY
```

Precedence is explicit > environment > keyless. The key is the **entire**
`Authorization` value: no `Bearer`, no other scheme word, because the API
checksums the raw header and a scheme word returns 401. Tests assert against five
scheme words rather than trusting review.

Host is never inferred from the key: free keys stay on the default `baseUrl`,
only Pro moves, and a free key sent to the Pro host returns 403.

### The User-Agent was three versions stale

```ts
'User-Agent': 'DexPaprika-SDK-JavaScript/0.1.0',   // while shipping 1.9.0
```

Every request misreported which SDK sent it, so no rollout could be measured. Now
from a `VERSION` constant in `src/version.ts`.

`rootDir` is `./src`, so importing `package.json` directly breaks the build. The
guard is a test asserting the constant matches the manifest instead, **and it
earned its place on the first run** by failing when I bumped the constant and not
the manifest.

### Browser safety, worth a look

Reading the environment is guarded rather than assumed:

```ts
const scope = globalThis as { process?: { env?: Record<string, string | undefined> } };
return scope.process?.env ?? {};
```

This package can be bundled for the browser, where `process` does not exist. A
bare `process.env` would have thrown there, and it would also have forced
`@types/node` into the tsconfig `types` field. This avoids both.

### Testing

New `npm run test:unit`, 13 assertions covering the bare-key format against five
scheme words, keyless behaviour including blank and whitespace-only values,
precedence, whitespace trimming, rejection of keys carrying CR/LF/NUL, the
absent-process path, version drift, and the host rules in both directions.

`tsc --noEmit` clean; the existing `tests/test-basic.ts` still passes against the
live API.