### PR TITLE
docs: the README claims a scheme word returns 401, and Bearer does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ const ohlcv = await client.pools.getOHLCV(
 
 ## Using an API key (optional)
 
-**The SDK works without a key and always will.** No signup, no card. Everything
+**The SDK works without a key.** No signup, no card. Everything
 below is optional.
 
 A free key raises the monthly credit allowance. It does **not** raise the
@@ -161,7 +161,7 @@ previous keyless behaviour unchanged. In a browser bundle, where there is no
 `process`, the environment is simply empty and the client stays keyless.
 
 **There is no `Bearer` prefix.** The key is sent as the entire `Authorization`
-value, which is what the API expects; a scheme word returns 401. You never write
+value, which is what the API expects; `ApiKey` or `Token` in front of it returns 401. You never write
 the header yourself, so this only matters when debugging what went out.
 
 **Pro customers** also pass the base URL, because the host does not change on its


### PR DESCRIPTION
Two sentences in the API-key section are inaccurate.

**"a scheme word returns 401"** is not true of `Bearer`. `api.dexpaprika.com` strips a case-insensitive `Bearer ` before the checksum, so a key sent that way authenticates. Verified against `/usage` with a unique URL per call and `cf-cache-status: BYPASS` on every one:

```
Authorization: api_...          200  {"plan":"free",...}
Authorization: Bearer api_...   200  {"plan":"free",...}
Authorization: bearer api_...   200  {"plan":"free",...}
Authorization: ApiKey api_...   401  {"message":"api key verification has failed"}
Authorization: Token  api_...   401  {"message":"api key verification has failed"}
Authorization: Basic  api_...   401  {"message":"api key verification has failed"}
```

The advice stands, the justification does not. Now names the scheme words that do fail.

**"works without a key and always will"** is a durable promise about product behaviour, and gating some endpoints behind registration is under discussion. Trimmed to what is true today. Keyless remains the default and nothing in the code changes.

Docs side: coinpaprika/dexpaprika-docs#127.

README only. No code, no release needed.
